### PR TITLE
Fix incorrect types (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,72 +81,72 @@ Available methods for a collection:
 
 ### Read operations
 
-| Name                          | Parameters                                                    | Description                                                                                                                                     |
-| ----------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| sha1()                        | none                                                          | Returns the file sha1 hash. May vary from read_raw because read_raw adds ID fields to the entries. Compare with stringify version of your file. |
-| read_raw()                    | none                                                          | Reads the entire collection                                                                                                                     |
-| get(id)                       | id: `String\|Name`                                            | Tries to get one element by its key                                                                                                             |
-| search(searchOptions, random) | searchOptions: `SearchOption[]` random?:`false\|true\|Number` | Searches collections and returns matching results. <br>You can randomize the output order with random as true or a given seed.                  |
-| searchKeys(keys)              | keys: `String[] \| Number[]`                                  | Searches collections with given keys and returns matching results                                                                               |
-| select(selectOption)          | selectOption: `{ field: String[] }`                           | Improved read_raw with field selection                                                                                                          |
-| random(max, seed, offset)     | max?: `Integer >= -1` seed?: `Integer` offset?:`Integer >= 0` | Reads random entries of collection                                                                                                              |
+| Name                          | Parameters                                                    | Description                                                                                                             |
+| ----------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| sha1()                        | none                                                          | Get the sha1 hash of the file. Can be used to see if same file content without downloading the file.                    |
+| readRaw()                     | none                                                          | Returns the whole content of the JSON. ID values are injected for easier iteration, so this may be different to sha1(). |
+| get(id)                       | id: `string \| number`                                        | Get an element from the collection.                                                                                     |
+| search(searchOptions, random) | searchOptions: `SearchOption[]` random?:`boolean \| number`   | Search through the collection You can randomize the output order with random as true or a given seed.                   |
+| searchKeys(keys)              | keys: `string[] \| number[]`                                  | Search specific keys through the collection.                                                                            |
+| select(selectOption)          | selectOption: `{ field: string[] }`                           | Get only selected fields from the collection Essentially an upgraded version of readRaw.                                |
+| random(max, seed, offset)     | max?: `integer >= -1` seed?: `integer` offset?:`integer >= 0` | Reads random entries of collection.                                                                                     |
 
-The search method can take one or more options to filter entries in a collection. A search option studies a `field` with a `criteria` and compares it to a `value`. You can also use the boolean `ignoreCase` option for string values.
+The search method can take one or more options to filter entries in a collection. A search option takes a `field` with a `criteria` and compares it to a `value`. You can also use the boolean `ignoreCase` option for string values.
 
 Not all criteria are available depending the field type. There are more options available than the firestore `where` command, allowing you to get better and faster search results.
 
 ### All search options available
 
-| Criteria               | Types allowed           | Description                                                                                       |
-| ---------------------- | ----------------------- | ------------------------------------------------------------------------------------------------- |
-| `'!='`                 | Boolean, Number, String | Searches if the entry field's value is different from yours                                       |
-| `'=='`                 | Boolean, Number, String | Searches if the entry field's value is equal to yours                                             |
-| `'>='`                 | Number, String          | Searches if the entry field's value is greater or equal than yours                                |
-| `'<='`                 | Number, String          | Searches if the entry field's value is equal to than yours                                        |
-| `'>'`                  | Number, String          | Searches if the entry field's value is greater than yours                                         |
-| `'<'`                  | Number, String          | Searches if the entry field's value is lower than yours                                           |
-| `'in'`                 | Number, String          | Searches if the entry field's value is in the array of values you gave                            |
-| `'includes'`           | String                  | Searches if the entry field's value includes your substring                                       |
-| `'startsWith'`         | String                  | Searches if the entry field's value starts with your substring                                    |
-| `'endsWith'`           | String                  | Searches if the entry field's value ends with your substring                                      |
-| `'array-contains'`     | Array                   | Searches if the entry field's array contains your value                                           |
-| `'array-contains-any'` | Array                   | Searches if the entry field's array ends contains your one value of more inside your values array |
-| `'array-length-eq'`    | Number                  | Searches if the entry field's array size is equal to your value                                   |
-| `'array-length-df'`    | Number                  | Searches if the entry field's array size is different from your value                             |
-| `'array-length-lt'`    | Number                  | Searches if the entry field's array size is lower than your value                                 |
-| `'array-length-gt'`    | Number                  | Searches if the entry field's array size is lower greater than your value                         |
-| `'array-length-le'`    | Number                  | Searches if the entry field's array size is lower or equal to your value                          |
-| `'array-length-ge'`    | Number                  | Searches if the entry field's array size is greater or equal to your value                        |
+| Criteria               | Types allowed                 | Description                                                                                       |
+| ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------- |
+| `'!='`                 | `boolean`, `number`, `string` | Searches if the entry field's value is different from yours                                       |
+| `'=='`                 | `boolean`, `number`, `string` | Searches if the entry field's value is equal to yours                                             |
+| `'>='`                 | `number`, `string`            | Searches if the entry field's value is greater or equal than yours                                |
+| `'<='`                 | `number`, `string`            | Searches if the entry field's value is equal to than yours                                        |
+| `'>'`                  | `number`, `string`            | Searches if the entry field's value is greater than yours                                         |
+| `'<'`                  | `number`, `string`            | Searches if the entry field's value is lower than yours                                           |
+| `'in'`                 | `number`, `string`            | Searches if the entry field's value is in the array of values you gave                            |
+| `'includes'`           | `string`                      | Searches if the entry field's value includes your substring                                       |
+| `'startsWith'`         | `string`                      | Searches if the entry field's value starts with your substring                                    |
+| `'endsWith'`           | `string`                      | Searches if the entry field's value ends with your substring                                      |
+| `'array-contains'`     | `Array`                       | Searches if the entry field's array contains your value                                           |
+| `'array-contains-any'` | `Array`                       | Searches if the entry field's array ends contains your one value of more inside your values array |
+| `'array-length-eq'`    | `number`                      | Searches if the entry field's array size is equal to your value                                   |
+| `'array-length-df'`    | `number`                      | Searches if the entry field's array size is different from your value                             |
+| `'array-length-lt'`    | `number`                      | Searches if the entry field's array size is lower than your value                                 |
+| `'array-length-gt'`    | `number`                      | Searches if the entry field's array size is lower greater than your value                         |
+| `'array-length-le'`    | `number`                      | Searches if the entry field's array size is lower or equal to your value                          |
+| `'array-length-ge'`    | `number`                      | Searches if the entry field's array size is greater or equal to your value                        |
 
 ### Write operations
 
-| Name                    | Parameters                                   | Description                                                                         |
-| ----------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------- |
-| writes_raw()            | none                                         | Writes the entire collection **/!\\ Very dangerous /!\\**                           |
-| add(value)              | value: `Object`                              | Adds one element with autoKey into the collection                                   |
-| addBulk(values)         | value: `Object[]`                            | Adds multiple elements with autoKey into the collection                             |
-| remove(key)             | key: `String\|Name`                          | Remove one element from the collection with the corresponding key                   |
-| removeBulk(keys)        | keys: `String[]\|Name[]`                     | Remove multiple elements from the collection with the corresponding keys            |
-| set(key, value)         | key: `String\|Name`, value: `Object`         | Sets one element with its key and value into the collection                         |
-| setBulk(keys, values)   | keys: `String[]\|Name[]`, values: `Object[]` | Sets multiple elements with their corresponding keys and values into the collection |
-| editField(obj)          | obj: `EditObject`                            | Changes one field of a given element in a collection                                |
-| editFieldBulk(objArray) | objArray: `EditObject[]`                     | Changes one field per element in a collection                                       |
+| Name                    | Parameters                                       | Description                                                                         |
+| ----------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| writeRaw()              | none                                             | Set the entire JSON file contents **/!\\ Very dangerous /!\\**                      |
+| add(value)              | value: `Object`                                  | Adds one element with autoKey into the collection                                   |
+| addBulk(values)         | value: `Object[]`                                | Adds multiple elements with autoKey into the collection                             |
+| remove(key)             | key: `string \| number`                          | Remove one element from the collection with the corresponding key                   |
+| removeBulk(keys)        | keys: `string[] \| number[]`                     | Remove multiple elements from the collection with the corresponding keys            |
+| set(key, value)         | key: `string \| number`, value: `Object`         | Sets one element with its key and value into the collection                         |
+| setBulk(keys, values)   | keys: `string[] \| number[]`, values: `Object[]` | Sets multiple elements with their corresponding keys and values into the collection |
+| editField(obj)          | obj: `EditObject`                                | Changes one field of a given element in a collection                                |
+| editFieldBulk(objArray) | objArray: `EditObject[]`                         | Changes one field per element in a collection                                       |
 
 ### Edit field operations
 
 Edit objects have an `id` to get the wanted element, a `field` they want to edit, an `operation` with what to do to this field, and a possible `value`. Here is a list of operations:
 
-| Operation      | Value required | Types allowed      | Description                                                                                                                                                          |
-| -------------- | -------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `set`          | Yes            | any                | Sets a field to a given value                                                                                                                                        |
-| `remove`       | No             | any                | Removes a field from the element                                                                                                                                     |
-| `append`       | Yes            | String             | Appends string at the end of the string field                                                                                                                        |
-| `invert`       | No             | any                | Inverts tate of boolean field                                                                                                                                        |
-| `increment`    | No             | Number             | Adds a number to the field, default is 1                                                                                                                             |
-| `decrement`    | No             | Number             | Retrieves a number to the field, default is -1                                                                                                                       |
-| `array-push `  | Yes            | any                | Push an element to the end of an array field                                                                                                                         |
-| `array-delete` | Yes            | Integer            | Removes and element at a certain index in an array field, check [array_splice documentation](https://www.php.net/manual/function.array-splice) offset for more infos |
-| `array-splice` | Yes            | [Integer, Integer] | Removes certain elements, check [array_splice documentation](https://www.php.net/manual/function.array-splice) offset and length for more infos                      |
+| Operation      | Value required | Types allowed        | Description                                                                                                                                                          |
+| -------------- | -------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `set`          | Yes            | `any`                | Sets a field to a given value                                                                                                                                        |
+| `remove`       | No             | `any`                | Removes a field from the element                                                                                                                                     |
+| `append`       | Yes            | `string`             | Appends string at the end of the string field                                                                                                                        |
+| `invert`       | No             | `any`                | Inverts tate of boolean field                                                                                                                                        |
+| `increment`    | No             | `number`             | Adds a number to the field, default is 1                                                                                                                             |
+| `decrement`    | No             | `number`             | Retrieves a number to the field, default is -1                                                                                                                       |
+| `array-push `  | Yes            | `any`                | Push an element to the end of an array field                                                                                                                         |
+| `array-delete` | Yes            | `integer`            | Removes and element at a certain index in an array field, check [array_splice documentation](https://www.php.net/manual/function.array-splice) offset for more infos |
+| `array-splice` | Yes            | `[integer, integer]` | Removes certain elements, check [array_splice documentation](https://www.php.net/manual/function.array-splice) offset and length for more infos                      |
 
 <br>
 
@@ -156,7 +156,7 @@ The PHP files are the ones handling files, read and writes. They also handle GET
 
 ## PHP setup
 
-The developer has to create 2 files at the root of this folder: `tokens.php` and `config.php`
+The developer has to create two main files at the root of their Firestorm setup: `tokens.php` and `config.php`.
 
 `tokens.php` will contain the tokens inside a `$db_tokens` value array with the tokens to use. You will use these tokens to write data or read private tables.
 
@@ -298,7 +298,7 @@ memory_limit = 256M
 
 ## API endpoints
 
-All Firestorm methods correspond to an equivalent Axios request. Read requests are GET request and write requests are POST requests with provided JSON data.
+All Firestorm methods correspond to an equivalent Axios request to the relevant PHP file. Read requests are GET requests and write requests are POST requests with provided JSON data.
 
 You always have the same first keys and the one key per method:
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typings/index.d.ts"
   ],
   "dependencies": {
-    "axios": "^1.6.2"
+    "axios": "^1.6.7"
   },
   "devDependencies": {
     "chai": "^4.3.10",
@@ -47,12 +47,11 @@
     "form-data": "^4.0.0",
     "glob": "^10.3.10",
     "jsdoc": "^4.0.2",
-    "jsdoc-to-markdown": "^8.0.0",
+    "jsdoc-to-markdown": "^8.0.1",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
-    "prettier": "^3.1.1",
+    "prettier": "^3.2.4",
     "recursive-copy": "^2.0.14",
-    "type-fest": "^4.8.3",
     "typescript": "^5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   axios:
-    specifier: ^1.6.2
-    version: 1.6.2
+    specifier: ^1.6.7
+    version: 1.6.7
 
 devDependencies:
   chai:
@@ -26,8 +26,8 @@ devDependencies:
     specifier: ^4.0.2
     version: 4.0.2
   jsdoc-to-markdown:
-    specifier: ^8.0.0
-    version: 8.0.0
+    specifier: ^8.0.1
+    version: 8.0.1
   mocha:
     specifier: ^10.2.0
     version: 10.2.0
@@ -35,14 +35,11 @@ devDependencies:
     specifier: ^15.1.0
     version: 15.1.0
   prettier:
-    specifier: ^3.1.1
-    version: 3.1.1
+    specifier: ^3.2.4
+    version: 3.2.4
   recursive-copy:
     specifier: ^2.0.14
     version: 2.0.14
-  type-fest:
-    specifier: ^4.8.3
-    version: 4.8.3
   typescript:
     specifier: ^5.3.3
     version: 5.3.3
@@ -480,10 +477,10 @@ packages:
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  /axios@1.6.2:
-    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
+  /axios@1.6.7:
+    resolution: {integrity: sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==}
     dependencies:
-      follow-redirects: 1.15.3
+      follow-redirects: 1.15.5
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -936,8 +933,8 @@ packages:
     hasBin: true
     dev: true
 
-  /follow-redirects@1.15.3:
-    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
+  /follow-redirects@1.15.5:
+    resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -1291,20 +1288,19 @@ packages:
       walk-back: 5.1.0
     dev: true
 
-  /jsdoc-parse@6.2.0:
-    resolution: {integrity: sha512-Afu1fQBEb7QHt6QWX/6eUWvYHJofB90Fjx7FuJYF7mnG9z5BkAIpms1wsnvYLytfmqpEENHs/fax9p8gvMj7dw==}
+  /jsdoc-parse@6.2.1:
+    resolution: {integrity: sha512-9viGRUUtWOk/G4V0+nQ6rfLucz5plxh5I74WbNSNm9h9NWugCDVX4jbG8hZP9QqKGpdTPDE+qJXzaYNos3wqTA==}
     engines: {node: '>=12'}
     dependencies:
       array-back: 6.2.2
       lodash.omit: 4.5.0
-      lodash.pick: 4.4.0
       reduce-extract: 1.0.0
       sort-array: 4.1.5
       test-value: 3.0.0
     dev: true
 
-  /jsdoc-to-markdown@8.0.0:
-    resolution: {integrity: sha512-2FQvYkg491+FP6s15eFlgSSWs69CvQrpbABGYBtvAvGWy/lWo8IKKToarT283w59rQFrpcjHl3YdhHCa3l7gXg==}
+  /jsdoc-to-markdown@8.0.1:
+    resolution: {integrity: sha512-qJfNJhkq2C26UYoOdj8L1yheTJlk1veCsxwRejRmj07XZKCn7oSkuPErx6+JoNi8afCaUKdIM5oUu0uF2/T8iw==}
     engines: {node: '>=12.17'}
     hasBin: true
     dependencies:
@@ -1313,7 +1309,7 @@ packages:
       config-master: 3.1.0
       dmd: 6.2.0
       jsdoc-api: 8.0.0
-      jsdoc-parse: 6.2.0
+      jsdoc-parse: 6.2.1
       walk-back: 5.1.0
     dev: true
 
@@ -1396,10 +1392,6 @@ packages:
 
   /lodash.padend@4.6.1:
     resolution: {integrity: sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==}
-    dev: true
-
-  /lodash.pick@4.4.0:
-    resolution: {integrity: sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==}
     dev: true
 
   /lodash@4.17.21:
@@ -1760,8 +1752,8 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /prettier@3.1.1:
-    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+  /prettier@3.2.4:
+    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true
@@ -2109,11 +2101,6 @@ packages:
   /type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
-    dev: true
-
-  /type-fest@4.8.3:
-    resolution: {integrity: sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==}
-    engines: {node: '>=16'}
     dev: true
 
   /typedarray-to-buffer@3.1.5:

--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ class Collection {
 	}
 
 	/**
-	 * Returns the whole content of the file
+	 * Returns the whole content of the JSON
 	 * @returns {Promise<Record<string, T>>} The entire collection
 	 */
 	readRaw() {
@@ -306,7 +306,7 @@ class Collection {
 	}
 
 	/**
-	 * Returns the whole content of the file
+	 * Returns the whole content of the JSON
 	 * @deprecated use readRaw instead
 	 * @returns {Promise<Record<string, T>>} The entire collection
 	 */
@@ -589,7 +589,7 @@ const firestorm = {
 	},
 
 	/**
-     * Create a temporary Firestorm collection with no methods
+	 * Create a temporary Firestorm collection with no methods
 	 * @template T
 	 * @param {string} name - The table name to get
 	 * @returns {Collection<T>} The collection

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,8 @@ try {
  */
 
 /**
- * @typedef {Confirmation}
- * @property {string} message - Confirmation that a write occurred
+ * @typedef {WriteConfirmation}
+ * @property {string} message - Write status
  */
 
 /** @ignore */
@@ -425,7 +425,7 @@ class Collection {
 	/**
 	 * Set the entire JSON file contents
 	 * @param {Record<string, T>} value - The value to write
-	 * @returns {Promise<Confirmation>} Write confirmation
+	 * @returns {Promise<WriteConfirmation>} Write confirmation
 	 */
 	writeRaw(value) {
 		if (value === undefined || value === null) {
@@ -438,7 +438,7 @@ class Collection {
 	 * Set the entire JSON file contents
 	 * @param {Record<string, T>} value - The value to write
 	 * @deprecated Use writeRaw instead
-	 * @returns {Promise<Confirmation>} Write confirmation
+	 * @returns {Promise<WriteConfirmation>} Write confirmation
 	 */
 	write_raw(value) {
 		return this.writeRaw(value);
@@ -485,7 +485,7 @@ class Collection {
 	/**
 	 * Remove an element from the collection by its ID
 	 * @param {string | number} key The key from the entry to remove
-	 * @returns {Promise<Confirmation>} Write confirmation
+	 * @returns {Promise<WriteConfirmation>} Write confirmation
 	 */
 	remove(key) {
 		return this.__extract_data(axios.post(writeAddress(), this.__write_data("remove", key)));
@@ -494,7 +494,7 @@ class Collection {
 	/**
 	 * Remove multiple elements from the collection by their IDs
 	 * @param {string[] | number[]} keys The key from the entries to remove
-	 * @returns {Promise<Confirmation>} Write confirmation
+	 * @returns {Promise<WriteConfirmation>} Write confirmation
 	 */
 	removeBulk(keys) {
 		return this.__extract_data(axios.post(writeAddress(), this.__write_data("removeBulk", keys)));
@@ -504,7 +504,7 @@ class Collection {
 	 * Set a value in the collection by ID
 	 * @param {string} key - The ID of the element you want to edit
 	 * @param {T} value - The value (without methods) you want to edit
-	 * @returns {Promise<Confirmation>} Write confirmation
+	 * @returns {Promise<WriteConfirmation>} Write confirmation
 	 */
 	set(key, value) {
 		const data = this.__write_data("set", value);
@@ -516,7 +516,7 @@ class Collection {
 	 * Set multiple values in the collection by their IDs
 	 * @param {string[]} keys - The IDs of the elements you want to edit
 	 * @param {T[]} values - The values (without methods) you want to edit
-	 * @returns {Promise<Confirmation>} Write confirmation
+	 * @returns {Promise<WriteConfirmation>} Write confirmation
 	 */
 	setBulk(keys, values) {
 		const data = this.__write_data("setBulk", values, true);

--- a/src/index.js
+++ b/src/index.js
@@ -4,38 +4,34 @@ try {
 
 /**
  * @typedef {Object} SearchOption
- * @property {string} field The field you want to search in
- * @property {"!=" | "==" | ">=" | "<=" | "<" | ">" | "in" | "includes" | "startsWith" | "endsWith" | "array-contains" | "array-contains-any" | "array-length-(eq|df|gt|lt|ge|le)" } criteria filter criteria
- * @property {string | number | boolean | Array } value the value you want to compare
- * @property {boolean} ignoreCase Ignore case on search string
+ * @property {string} field - The field you want to search in
+ * @property {"!=" | "==" | ">=" | "<=" | "<" | ">" | "in" | "includes" | "startsWith" | "endsWith" | "array-contains" | "array-contains-any" | "array-length-(eq|df|gt|lt|ge|le)" } criteria - Filter criteria
+ * @property {string | number | boolean | Array } value - The value you want to compare
+ * @property {boolean} ignoreCase - Ignore case on search string
  */
 
 /**
  * @typedef {Object} EditObject
- * @property {string | number } id the affected element
- * @property {string} field The field you want to edit
- * @property {"set" | "remove" | "append" | "increment" | "decrement" | "array-push" | "array-delete" | "array-splice"} operation Wanted operation on field
- * @property {string | number | boolean | Array } [value] // the value you want to compare
+ * @property {string | number } id - The affected element
+ * @property {string} field - The field you want to edit
+ * @property {"set" | "remove" | "append" | "increment" | "decrement" | "array-push" | "array-delete" | "array-splice"} operation - Wanted operation on field
+ * @property {string | number | boolean | Array} [value] - The value you want to compare
  */
 
 /**
  * @typedef {Object} SelectOption
- * @property {Array<string>} fields Chosen fields to eventually return
+ * @property {Array<string>} fields - Chosen fields to eventually return
  */
 
 /**
  * @typedef {Confirmation}
- * @property {string} message
+ * @property {string} message - Confirmation that a write occurred
  */
 
-/**
- * @ignore
- */
+/** @ignore */
 let _address = undefined;
 
-/**
- * @ignore
- */
+/** @ignore */
 let _token = undefined;
 
 const ID_FIELD_NAME = "id";
@@ -307,7 +303,7 @@ class Collection {
 
 	/**
 	 * Returns the whole content of the JSON
-	 * @deprecated use readRaw instead
+	 * @deprecated Use readRaw instead
 	 * @returns {Promise<Record<string, T>>} The entire collection
 	 */
 	read_raw() {

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ class Collection {
 	/**
 	 * Create a new Firestorm collection instance
 	 * @param {string} name - The name of the collection
-	 * @param {(Collection<T> & T) => Collection<T> & T} [addMethods] - Additional methods and data to add to the objects
+	 * @param {Function} [addMethods] - Additional methods and data to add to the objects
 	 */
 	constructor(name, addMethods = (el) => el) {
 		if (name === undefined) throw new SyntaxError("Collection must have a name");
@@ -581,7 +581,7 @@ const firestorm = {
 	 * Create a new Firestorm collection instance
 	 * @template T
 	 * @param {string} name - The name of the collection
-	 * @param {(Collection<T> & T) => Collection<T> & T} [addMethods] - Additional methods and data to add to the objects
+	 * @param {Function} [addMethods] - Additional methods and data to add to the objects
 	 * @returns {Collection<T>} The collection
 	 */
 	collection(name, addMethods = (el) => el) {

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,11 @@ try {
  */
 
 /**
+ * @typedef {Confirmation}
+ * @property {string} message
+ */
+
+/**
  * @ignore
  */
 let _address = undefined;
@@ -87,8 +92,9 @@ const __extract_data = (request) => {
  */
 class Collection {
 	/**
-	 * @param {string} name The name of the Collection
-	 * @param {Function} [addMethods] Additional methods and data to add to the objects
+	 * Create a new Firestorm collection instance
+	 * @param {string} name - The name of the collection
+	 * @param {(Collection<T> & T) => Collection<T> & T} [addMethods] - Additional methods and data to add to the objects
 	 */
 	constructor(name, addMethods = (el) => el) {
 		if (name === undefined) throw new SyntaxError("Collection must have a name");
@@ -102,8 +108,8 @@ class Collection {
 	 * Add user methods to the returned data
 	 * @private
 	 * @ignore
-	 * @param {AxiosPromise} req Incoming request
-	 * @returns {Object|Object[]}
+	 * @param {AxiosPromise} req - Incoming request
+	 * @returns {Object | Object[]}
 	 */
 	__add_methods(req) {
 		return new Promise((resolve, reject) => {
@@ -127,7 +133,7 @@ class Collection {
 	 * Auto-extracts data from Axios request
 	 * @private
 	 * @ignore
-	 * @param {AxiosPromise} request The Axios concerned request
+	 * @param {AxiosPromise} request - The Axios concerned request
 	 */
 	__extract_data(request) {
 		return __extract_data(request);
@@ -137,7 +143,7 @@ class Collection {
 	 * Send get request and extract data from response
 	 * @private
 	 * @ignore
-	 * @param {Object} data Body data
+	 * @param {Object} data - Body data
 	 * @returns {Promise<Object|Object[]>} data out
 	 */
 	__get_request(data) {
@@ -152,8 +158,8 @@ class Collection {
 
 	/**
 	 * Get an element from the collection
-	 * @param {string | number} id The entry ID
-	 * @returns {Promise<T>} Result entry you may be looking for
+	 * @param {string | number} id - The ID of the element you want to get
+	 * @returns {Promise<T>} Corresponding value
 	 */
 	get(id) {
 		return this.__add_methods(
@@ -166,7 +172,9 @@ class Collection {
 	}
 
 	/**
-	 * @returns {string} returns sha1 hash of the file. can be used to see if same file content without downloading the file for example
+	 * Get the sha1 hash of the file
+	 * - Can be used to see if same file content without downloading the file
+	 * @returns {string} The sha1 hash of the file
 	 */
 	sha1() {
 		return this.__get_request({
@@ -177,9 +185,9 @@ class Collection {
 
 	/**
 	 * Search through collection
-	 * @param {SearchOption[]} searchOptions Array of search options
-	 * @param {(number | false | true)} [random] Random result seed, disabled by default, but can activated with true or a given seed
-	 * @returns {Promise<T[]>}
+	 * @param {SearchOption[]} searchOptions - Array of search options
+	 * @param {boolean | number} [random] - Random result seed, disabled by default, but can activated with true or a given seed
+	 * @returns {Promise<T[]>} The found elements
 	 */
 	search(searchOptions, random = false) {
 		if (!Array.isArray(searchOptions))
@@ -249,8 +257,8 @@ class Collection {
 
 	/**
 	 * Search specific keys through collection
-	 * @param {string[] | number[]} keys Wanted keys
-	 * @returns {Promise<T[]>} Search results
+	 * @param {string[] | number[]} keys - Array of keys to search
+	 * @returns {Promise<T[]>} The found elements
 	 */
 	searchKeys(keys) {
 		if (!Array.isArray(keys)) return Promise.reject("Incorrect keys");
@@ -276,15 +284,8 @@ class Collection {
 	}
 
 	/**
-	 * @deprecated use readRaw instead
-	 */
-	read_raw() {
-		return this.readRaw();
-	}
-
-	/**
 	 * Returns the whole content of the file
-	 * @returns {Promise} // the get promise of the collection raw file content
+	 * @returns {Promise<Record<string, T>>} The entire collection
 	 */
 	readRaw() {
 		return new Promise((resolve, reject) => {
@@ -305,8 +306,19 @@ class Collection {
 	}
 
 	/**
-	 * Upgraded read raw with field selection
-	 * @param {SelectOption} selectOption Select options
+	 * Returns the whole content of the file
+	 * @deprecated use readRaw instead
+	 * @returns {Promise<Record<string, T>>} The entire collection
+	 */
+	read_raw() {
+		return this.readRaw();
+	}
+
+	/**
+	 * Get only selected fields from the collection
+	 * - Essentially an upgraded version of readRaw
+	 * @param {SelectOption} selectOption - Select options
+	 * @returns {Promise<Record<string, Partial<T>>>} Selected fields
 	 */
 	select(selectOption) {
 		if (!selectOption) selectOption = {};
@@ -330,10 +342,10 @@ class Collection {
 
 	/**
 	 * Returns random max entries offsets with a given seed
-	 * @param {number} max integer
-	 * @param {number} seed integer
-	 * @param {number} offset integer
-	 * @returns {Promise} entries
+	 * @param {number} max - The maximum number of entries
+	 * @param {number} seed - The seed to use
+	 * @param {number} offset - The offset to use
+	 * @returns {Promise<T[]>} The found elements
 	 */
 	random(max, seed, offset) {
 		const params = {};
@@ -415,9 +427,9 @@ class Collection {
 	}
 
 	/**
-	 * Writes the raw JSON file
-	 * @param {Object} value The whole JSON to write
-	 * @returns {Promise<any>}
+	 * Set the entire JSON file contents
+	 * @param {Record<string, T>} value - The value to write
+	 * @returns {Promise<Confirmation>} Write confirmation
 	 */
 	writeRaw(value) {
 		if (value === undefined || value === null) {
@@ -427,19 +439,19 @@ class Collection {
 	}
 
 	/**
-	 * Writes the raw JSON file
-	 * @param {Object} value
-	 * @deprecated use writeRaw instead
-	 * @returns {Promise<any>}
+	 * Set the entire JSON file contents
+	 * @param {Record<string, T>} value - The value to write
+	 * @deprecated Use writeRaw instead
+	 * @returns {Promise<Confirmation>} Write confirmation
 	 */
 	write_raw(value) {
 		return this.writeRaw(value);
 	}
 
 	/**
-	 * Add automatically a value to the JSON
-	 * @param {Object} value The value to add
-	 * @returns {Promise<any>}
+	 * Automatically add a value to the JSON file
+	 * @param {T} value - The value (without methods) to add
+	 * @returns {Promise<string>} The generated ID of the added element
 	 */
 	add(value) {
 		return new Promise((resolve, reject) => {
@@ -460,9 +472,9 @@ class Collection {
 	}
 
 	/**
-	 * Add automatically multiple values to the JSON
-	 * @param {Object[]} values The values to add
-	 * @returns {Promise<any>}
+	 * Automatically add multiple values to the JSON file
+	 * @param {Object[]} values - The values (without methods) to add
+	 * @returns {Promise<string[]>} The generated IDs of the added elements
 	 */
 	addBulk(values) {
 		return new Promise((resolve, reject) => {
@@ -475,28 +487,28 @@ class Collection {
 	}
 
 	/**
-	 * Remove entry with its key from the JSON
+	 * Remove an element from the collection by its ID
 	 * @param {string | number} key The key from the entry to remove
-	 * @returns {Promise<any>}
+	 * @returns {Promise<Confirmation>} Write confirmation
 	 */
 	remove(key) {
 		return this.__extract_data(axios.post(writeAddress(), this.__write_data("remove", key)));
 	}
 
 	/**
-	 * Remove entry with their keys from the JSON
+	 * Remove multiple elements from the collection by their IDs
 	 * @param {string[] | number[]} keys The key from the entries to remove
-	 * @returns {Promise<any>}
+	 * @returns {Promise<Confirmation>} Write confirmation
 	 */
 	removeBulk(keys) {
 		return this.__extract_data(axios.post(writeAddress(), this.__write_data("removeBulk", keys)));
 	}
 
 	/**
-	 * Sets an entry in the JSON
-	 * @param {string} key The key of the value you want to set
-	 * @param {Object} value The value you want for this key
-	 * @returns {Promise<any>}
+	 * Set a value in the collection by ID
+	 * @param {string} key - The ID of the element you want to edit
+	 * @param {T} value - The value (without methods) you want to edit
+	 * @returns {Promise<Confirmation>} Write confirmation
 	 */
 	set(key, value) {
 		const data = this.__write_data("set", value);
@@ -505,10 +517,10 @@ class Collection {
 	}
 
 	/**
-	 * Sets multiple entries in the JSON
-	 * @param {string[]} keys The array of keys of the values you want to set
-	 * @param {Object[]} values The values you want for these keys
-	 * @returns {Promise<any>}
+	 * Set multiple values in the collection by their IDs
+	 * @param {string[]} keys - The IDs of the elements you want to edit
+	 * @param {T[]} values - The values (without methods) you want to edit
+	 * @returns {Promise<Confirmation>} Write confirmation
 	 */
 	setBulk(keys, values) {
 		const data = this.__write_data("setBulk", values, true);
@@ -517,9 +529,9 @@ class Collection {
 	}
 
 	/**
-	 * Changes one field from an element in this collection
-	 * @param {EditObject} obj The edit object
-	 * @returns {Promise<any>}
+	 * Edit one field of the collection
+	 * @param {EditObject} obj - The edit object
+	 * @returns {Promise<T>} The edited element
 	 */
 	editField(obj) {
 		const data = this.__write_data("editField", obj, null);
@@ -529,7 +541,7 @@ class Collection {
 	/**
 	 * Changes one field from an element in this collection
 	 * @param {EditObject[]} objArray The edit object array with operations
-	 * @returns {Promise<any>}
+	 * @returns {Promise<T[]>} The edited elements
 	 */
 	editFieldBulk(objArray) {
 		const data = this.__write_data("editFieldBulk", objArray, undefined);
@@ -542,9 +554,9 @@ class Collection {
  */
 const firestorm = {
 	/**
-	 * @param {string} newValue The new address value
-	 * @returns {string} The stored address value
-	 * @memberof firestorm
+	 * Change the current Firestorm address
+	 * @param {string} [newValue] - The new Firestorm address
+	 * @returns {string} The stored Firestorm address
 	 */
 	address(newValue = undefined) {
 		if (newValue === undefined) return readAddress();
@@ -554,8 +566,9 @@ const firestorm = {
 	},
 
 	/**
-	 * @param {string} newValue The new write token
-	 * @returns {string} The stored write token
+	 * Change the current Firestorm token
+	 * @param {string} [newValue] - The new Firestorm write token
+	 * @returns {string} The stored Firestorm write token
 	 */
 	token(newValue = undefined) {
 		if (newValue === undefined) return writeToken();
@@ -563,26 +576,29 @@ const firestorm = {
 
 		return _token;
 	},
+
 	/**
-	 * @param {string} name Collection name to get
-	 * @param {Function} addMethods Additional methods and data to add to the objects
-	 * @returns {Collection}
+	 * Create a new Firestorm collection instance
+	 * @template T
+	 * @param {string} name - The name of the collection
+	 * @param {(Collection<T> & T) => Collection<T> & T} [addMethods] - Additional methods and data to add to the objects
+	 * @returns {Collection<T>} The collection
 	 */
 	collection(name, addMethods = (el) => el) {
 		return new Collection(name, addMethods);
 	},
 
 	/**
-	 *
-	 * @param {string} name Table name to get
+     * Create a temporary Firestorm collection with no methods
+	 * @template T
+	 * @param {string} name - The table name to get
+	 * @returns {Collection<T>} The collection
 	 */
 	table(name) {
 		return this.collection(name);
 	},
 
-	/**
-	 * Value for the id field when researching content
-	 */
+	/** Value for the id field when researching content */
 	ID_FIELD: ID_FIELD_NAME,
 
 	/**
@@ -593,9 +609,9 @@ const firestorm = {
 	 */
 	files: {
 		/**
-		 * gets file back
+		 * Get file back
 		 * @memberof firestorm.files
-		 * @param {string} path File path wanted
+		 * @param {string} path - The file path wanted
 		 */
 		get(path) {
 			return __extract_data(
@@ -610,8 +626,8 @@ const firestorm = {
 		/**
 		 * Uploads file
 		 * @memberof firestorm.files
-		 * @param {FormData} form formData with path, filename and file
-		 * @returns {Promise} http response
+		 * @param {FormData} form - The form data with path, filename, and file
+		 * @returns {Promise<any>} HTTP response
 		 */
 		upload(form) {
 			form.append("token", firestorm.token());
@@ -625,8 +641,8 @@ const firestorm = {
 		/**
 		 * Deletes a file given its path
 		 * @memberof firestorm.files
-		 * @param {string} path File path to delete
-		 * @returns {Promise} http response
+		 * @param {string} path - The file path to delete
+		 * @returns {Promise<any>} HTTP response
 		 */
 		delete(path) {
 			return axios.delete(fileAddress(), {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -164,8 +164,9 @@ export type NoMethods<T> = {
 
 export class Collection<T> {
 	/**
+	 * Create a new Firestorm collection instance
 	 * @param name - The name of the collection
-	 * @param addMethods - The methods you want to add to the collection
+	 * @param addMethods - Additional methods and data to add to the objects
 	 */
 	public constructor(name: string, addMethods?: CollectionMethods<T>);
 
@@ -216,6 +217,7 @@ export class Collection<T> {
 
 	/**
 	 * Get only selected fields from the collection
+	 * - Essentially an upgraded version of readRaw
 	 * @param option - The option you want to select
 	 * @returns Selected fields
 	 */
@@ -311,30 +313,33 @@ export const ID_FIELD: string;
 type Writable<T> = Omit<Omit<T, NoMethods<T>>, "id">;
 
 /**
- * Change the current firestorm address
- * @param value - The new firestorm address
- * @returns The stored firestorm address
+ * Change the current Firestorm address
+ * @param value - The new Firestorm address
+ * @returns The stored Firestorm address
  */
 export function address(value?: string): string;
 
 /**
- * @param value - The new firestorm write token
- * @returns The stored firestorm write token
+ * Change the current Firestorm token
+ * @param value - The new Firestorm write token
+ * @returns The stored Firestorm write token
  */
-export function token(value: string): string;
+export function token(value?: string): string;
 
 /**
  * Create a new Firestorm collection instance
- * @param value - Firestorm collection name
- * @param addMethods - Additional methods you want to add to the collection
+ * @param value - The name of the collection
+ * @param addMethods - Additional methods and data to add to the objects
  * @returns The collection
  */
 export function collection<T>(value: string, addMethods?: CollectionMethods<T>): Collection<T>;
 
 /**
+ * Create a temporary Firestorm collection with no methods
  * @param table - The table name to get
+ * @returns The collection
  */
-export function table(table: string): Promise<any>;
+export function table<T>(table: string): Promise<Collection<T>>;
 
 /**
  * Firestorm file handler
@@ -348,15 +353,15 @@ export declare const files: {
 
 	/**
 	 * Upload file
-	 * @param form - The form data with path, filename & file
-	 * @returns http response
+	 * @param form - The form data with path, filename, and file
+	 * @returns HTTP response
 	 */
 	upload(form: FormData): Promise<any>;
 
 	/**
 	 * Deletes a file given its path
 	 * @param path - The file path to delete
-	 * @returns http response
+	 * @returns HTTP response
 	 */
 	delete(path: string): Promise<any>;
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -134,6 +134,8 @@ export type EditField<T> = {
 		);
 }[keyof T];
 
+export type Confirmation = { message: string };
+
 export type SearchOption<T> = {
 	[K in keyof T]: {
 		/** the field to be searched for */
@@ -169,13 +171,14 @@ export class Collection<T> {
 
 	/**
 	 * Get an element from the collection
-	 * @param id - The id of the element you want to get
+	 * @param id - The ID of the element you want to get
+	 * @returns Corresponding value
 	 */
 	public get(id: string | number): Promise<T>;
 
 	/**
-	 * Get the sha1 hash of the file.
-	 * - Can be used to see if same file content without downloading the file for example
+	 * Get the sha1 hash of the file
+	 * - Can be used to see if same file content without downloading the file
 	 * @returns The sha1 hash of the file
 	 */
 	public sha1(): string;
@@ -212,11 +215,11 @@ export class Collection<T> {
 	public read_raw(): Promise<Record<string, T>>;
 
 	/**
-	 * Get only selected elements from the collection
+	 * Get only selected fields from the collection
 	 * @param option - The option you want to select
-	 * @returns Only selected elements from T
+	 * @returns Selected fields
 	 */
-	public select(option: SelectOption<T>): Promise<any[]>;
+	public select(option: SelectOption<T>): Promise<Record<string, Partial<T>>>;
 
 	/**
 	 * Get random max entries offset with a given seed
@@ -228,63 +231,63 @@ export class Collection<T> {
 	public random(max: number, seed: number, offset: number): Promise<T[]>;
 
 	/**
-	 * Write the whole content in the JSON file
+	 * Set the entire JSON file contents
 	 * @param value - The value to write
-	 * @returns The written elements
+	 * @returns Write confirmation
 	 */
-	public writeRaw(value: Record<string, T>): Promise<string>;
+	public writeRaw(value: Record<string, T>): Promise<Confirmation>;
 
 	/**
-	 * Write the whole content in the JSON file
-	 * @param value - The value to write
+	 * Set the entire JSON file contents
 	 * @deprecated Use writeRaw instead
-	 * @returns The written elements
+	 * @param value - The value to write
+	 * @returns Write confirmation
 	 */
-	public write_raw(value: Record<string, T>): Promise<string>;
+	public write_raw(value: Record<string, T>): Promise<Confirmation>;
 
 	/**
-	 * Add automatically a value to the JSON file
-	 * @param value - The value, without methods, to add
-	 * @returns The id of the added element
+	 * Automatically add a value to the JSON file
+	 * @param value - The value (without methods) to add
+	 * @returns The generated ID of the added element
 	 */
 	public add(value: Writable<T>): Promise<string>;
 
 	/**
-	 * Add automatically multiple values to the JSON file
-	 * @param values - The values, without methods, to add
-	 * @returns The ids of the added elements
+	 * Automatically add multiple values to the JSON file
+	 * @param values - The values (without methods) to add
+	 * @returns The generated IDs of the added elements
 	 */
 	public addBulk(values: Writable<T>[]): Promise<string[]>;
 
 	/**
-	 * Remove an element from the collection by its id
-	 * @param id - The id of the element you want to remove
-	 * @returns The id of the removed element
+	 * Remove an element from the collection by its ID
+	 * @param id - The ID of the element you want to remove
+	 * @returns Write confirmation
 	 */
-	public remove(id: string | number): Promise<string>;
+	public remove(id: string | number): Promise<Confirmation>;
 
 	/**
-	 * Remove multiple elements from the collection by their ids
-	 * @param ids - The ids of the elements you want to remove
-	 * @returns The ids of the removed elements
+	 * Remove multiple elements from the collection by their IDs
+	 * @param ids - The IDs of the elements you want to remove
+	 * @returns Write confirmation
 	 */
-	public removeBulk(ids: string[] | number[]): Promise<string>;
+	public removeBulk(ids: string[] | number[]): Promise<Confirmation>;
 
 	/**
-	 * Set a value in the collection by its id
-	 * @param id - The id of the element you want to edit
-	 * @param value - The value, without methods, you want to edit
-	 * @returns The edited element
+	 * Set a value in the collection by ID
+	 * @param id - The ID of the element you want to edit
+	 * @param value - The value (without methods) you want to edit
+	 * @returns Write confirmation
 	 */
-	public set(id: string | number, value: Writable<T>): Promise<string>;
+	public set(id: string | number, value: Writable<T>): Promise<Confirmation>;
 
 	/**
-	 * Set multiple values in the collection by their ids
-	 * @param ids - The ids of the elements you want to edit
-	 * @param values - The values, without methods, you want to edit
-	 * @returns The edited elements
+	 * Set multiple values in the collection by their IDs
+	 * @param ids - The IDs of the elements you want to edit
+	 * @param values - The values (without methods) you want to edit
+	 * @returns Write confirmation
 	 */
-	public setBulk(ids: string[] | number[], values: Writable<T>[]): Promise<string>;
+	public setBulk(ids: string[] | number[], values: Writable<T>[]): Promise<Confirmation>;
 
 	/**
 	 * Edit one field of the collection
@@ -304,7 +307,7 @@ export class Collection<T> {
 /** Value for the id field when searching content */
 export const ID_FIELD: string;
 
-// don't need ID field when adding keys, and settings keys has a separate id argument
+// don't need ID field when adding keys, and setting keys has a separate ID argument
 type Writable<T> = Omit<Omit<T, NoMethods<T>>, "id">;
 
 /**
@@ -321,7 +324,8 @@ export function address(value?: string): string;
 export function token(value: string): string;
 
 /**
- * @param value - The new firestorm read token
+ * Create a new Firestorm collection instance
+ * @param value - Firestorm collection name
  * @param addMethods - Additional methods you want to add to the collection
  * @returns The collection
  */
@@ -332,28 +336,30 @@ export function collection<T>(value: string, addMethods?: CollectionMethods<T>):
  */
 export function table(table: string): Promise<any>;
 
-/** we need to use an abstract class here because `delete` is reserved otherwise */
-export abstract class files {
+/**
+ * Firestorm file handler
+ */
+export declare const files: {
 	/**
 	 * Get file back
 	 * @param path - The file path wanted
 	 */
-	static get: (path: string) => any;
+	get(path: string): Promise<any>;
 
 	/**
 	 * Upload file
 	 * @param form - The form data with path, filename & file
 	 * @returns http response
 	 */
-	static upload: (form: FormData) => Promise<any>;
+	upload(form: FormData): Promise<any>;
 
 	/**
 	 * Deletes a file given its path
 	 * @param path - The file path to delete
 	 * @returns http response
 	 */
-	static delete: (path: string) => Promise<any>;
-}
+	delete(path: string): Promise<any>;
+};
 
 /**
  * taken from https://github.com/toonvanstrijp/nestjs-i18n/blob/3fc33c105a68b112ed7af6237c5f49902d0864b6/src/types.ts#L27

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -134,8 +134,8 @@ export type EditField<T> = {
 		);
 }[keyof T];
 
-/** Confirmation that a write occurred */
-export type Confirmation = { message: string };
+/** Write status */
+export type WriteConfirmation = { message: string };
 
 export type SearchOption<T> = {
 	[K in keyof T]: {
@@ -238,7 +238,7 @@ export class Collection<T> {
 	 * @param value - The value to write
 	 * @returns Write confirmation
 	 */
-	public writeRaw(value: Record<string, T>): Promise<Confirmation>;
+	public writeRaw(value: Record<string, T>): Promise<WriteConfirmation>;
 
 	/**
 	 * Set the entire JSON file contents
@@ -246,7 +246,7 @@ export class Collection<T> {
 	 * @param value - The value to write
 	 * @returns Write confirmation
 	 */
-	public write_raw(value: Record<string, T>): Promise<Confirmation>;
+	public write_raw(value: Record<string, T>): Promise<WriteConfirmation>;
 
 	/**
 	 * Automatically add a value to the JSON file
@@ -267,14 +267,14 @@ export class Collection<T> {
 	 * @param id - The ID of the element you want to remove
 	 * @returns Write confirmation
 	 */
-	public remove(id: string | number): Promise<Confirmation>;
+	public remove(id: string | number): Promise<WriteConfirmation>;
 
 	/**
 	 * Remove multiple elements from the collection by their IDs
 	 * @param ids - The IDs of the elements you want to remove
 	 * @returns Write confirmation
 	 */
-	public removeBulk(ids: string[] | number[]): Promise<Confirmation>;
+	public removeBulk(ids: string[] | number[]): Promise<WriteConfirmation>;
 
 	/**
 	 * Set a value in the collection by ID
@@ -282,7 +282,7 @@ export class Collection<T> {
 	 * @param value - The value (without methods) you want to edit
 	 * @returns Write confirmation
 	 */
-	public set(id: string | number, value: Writable<T>): Promise<Confirmation>;
+	public set(id: string | number, value: Writable<T>): Promise<WriteConfirmation>;
 
 	/**
 	 * Set multiple values in the collection by their IDs
@@ -290,7 +290,7 @@ export class Collection<T> {
 	 * @param values - The values (without methods) you want to edit
 	 * @returns Write confirmation
 	 */
-	public setBulk(ids: string[] | number[], values: Writable<T>[]): Promise<Confirmation>;
+	public setBulk(ids: string[] | number[], values: Writable<T>[]): Promise<WriteConfirmation>;
 
 	/**
 	 * Edit one field of the collection

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -134,6 +134,7 @@ export type EditField<T> = {
 		);
 }[keyof T];
 
+/** Confirmation that a write occurred */
 export type Confirmation = { message: string };
 
 export type SearchOption<T> = {
@@ -144,7 +145,7 @@ export type SearchOption<T> = {
 		criteria: Criteria<T[K]>;
 		/** the value to be searched for */
 		value?: any;
-		/** is it case sensitive? (default: true) */
+		/** is it case sensitive? (default true) */
 		ignoreCase?: boolean;
 	};
 }[keyof T];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -203,13 +203,13 @@ export class Collection<T> {
 	public searchKeys(keys: string[] | number[]): Promise<T[]>;
 
 	/**
-	 * Returns the whole content of the file
+	 * Returns the whole content of the JSON
 	 * @returns The entire collection
 	 */
 	public readRaw(): Promise<Record<string, T>>;
 
 	/**
-	 * Returns the whole content of the file
+	 * Returns the whole content of the JSON
 	 * @deprecated Use readRaw instead
 	 * @returns The entire collection
 	 */


### PR DESCRIPTION
All of the Firestorm write methods actually return confirmations, not the written elements. The types don't reflect this at all, so I've updated them to be correct.

Additionally, I've fixed the `Collection.select()` return type, improved the grammar of the JSDoc comments, and updated the actual JavaScript file to use the TypeScript documentation and types.