### PR TITLE
Fix ID_FIELD typing and use modern async/await everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `array-contains-all` option for array fields.
+
 ### Changed
 
 - Changed PHP file representation from an associative array to a strongly-typed FileObject class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed PHP file representation from an associative array to a strongly-typed FileObject class.
+- Use modern async/await (supported in all major browers/Node.js since 2017).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed PHP file representation from an associative array to a strongly-typed FileObject class.
 - Reduced payload size for `Collection.get`.
-- Use modern async/await (supported in all major browers/Node.js since 2017).
+- Use modern async/await for client code (supported in all major browers/Node.js since 2017).
+- Made `firestorm.files.get` a generic method for increased type safety.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed PHP file representation from an associative array to a strongly-typed FileObject class.
 
+### Fixed
+
+- Fixed `ID_FIELD` TypeScript type.
+
 ## [1.13.0] - 2024-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed PHP file representation from an associative array to a strongly-typed FileObject class.
+- Reduced payload size for `Collection.get`.
 - Use modern async/await (supported in all major browers/Node.js since 2017).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.13.0] - 2024-05-09
+## Unreleased
+
+### Changed
+
+- Changed PHP file representation from an associative array to a strongly-typed FileObject class.
+
+## [1.13.0] - 2024-05-09
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The search method can take one or more options to filter entries in a collection
 | `'array-contains'`      | `Array`                       | Entry field's array contains your value                         |
 | `'array-contains-none'` | `Array`                       | Entry field's array contains no values from your array          |
 | `'array-contains-any'`  | `Array`                       | Entry field's array contains at least one value from your array |
+| `'array-contains-all'`  | `Array`                       | Entry field's array contains every value from your array        |
 | `'array-length-eq'`     | `number`                      | Entry field's array size is equal to your value                 |
 | `'array-length-df'`     | `number`                      | Entry field's array size is different from your value           |
 | `'array-length-lt'`     | `number`                      | Entry field's array size is lower than your value               |

--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
   "scripts": {
     "php:start": "node tests/php_setup.mjs",
     "php:stop": "sh tests/php_server_kill.sh",
-    "php:tests": "npm run php:stop ; npm run php:start && npm run js:tests ; npm run php:stop",
+    "php:tests": "pnpm php:stop ; pnpm php:start && pnpm js:tests ; pnpm php:stop",
     "js:tests": "mocha tests/**/tests-setup.spec.mjs tests/**/*.spec.mjs",
     "docker:build": "bash docker/docker_image_build.bash",
     "docker:alive": "bash docker/docker_image_alive.bash",
     "docker:tests": "bash docker/docker_image_tests.bash",
     "docker:start": "bash docker/docker_image_start.bash",
     "doc:gen": "jsdoc src/index.js -c jsdoc.json -R README.md -t ./node_modules/docdash -d out",
-    "doc:watch": "nodemon -x npm run doc:gen --watch src/index.js --watch jsdoc.json --watch README.md",
+    "doc:watch": "nodemon -x pnpm doc:gen --watch src/index.js --watch jsdoc.json --watch README.md",
     "types:gen": "npx tsc",
     "lint:prettier": "prettier \"{,!(node_modules)/**/}*.{cjs,mjs,js,ts}\" --config .prettierrc --write",
-    "coverage": "npm run php:stop ; npm run php:start && nyc --reporter=text mocha tests/**/*.spec.js; npm run php:stop"
+    "coverage": "pnpm php:stop ; pnpm php:start && nyc --reporter=text mocha tests/**/*.spec.js; pnpm php:stop"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "form-data": "^4.0.0"
   },
   "devDependencies": {
+    "@types/mocha": "^10.0.10",
     "chai": "^4.4.1",
     "consola": "^3.4.0",
     "docdash": "^2.0.2",

--- a/php/classes/JSONDatabase.php
+++ b/php/classes/JSONDatabase.php
@@ -30,13 +30,13 @@ class JSONDatabase {
         $this->autoIncrement = $autoIncrement;
     }
 
-    public function fullPath() {
+    public function fullPath(): string {
         return $this->folderPath . $this->fileName . $this->fileExt;
     }
 
     public function write_raw($content) {
         $content_type = gettype($content);
-        $incorrect_types = array('integer', 'double', 'string', 'boolean');
+        $incorrect_types = ['integer', 'double', 'string', 'boolean'];
 
         // content must not be primitive
         if (in_array($content_type, $incorrect_types)) {
@@ -78,24 +78,24 @@ class JSONDatabase {
         return file_put_contents($this->fullPath(), $content, LOCK_EX);
     }
 
-    private function write($obj) {
-        $obj['content'] = stringifier($obj['content'], 1);
+    private function write(FileObject $obj) {
+        $obj->content = stringifier($obj->content, 1);
         return FileAccess::write($obj);
     }
 
     public function sha1() {
         $obj = $this->read_raw();
-        return sha1($obj['content']);
+        return sha1($obj->content);
     }
 
-    public function read_raw($waitLock = false) {
+    public function read_raw($waitLock = false): FileObject {
         // fall back to empty array if failed
-        return FileAccess::read($this->fullPath(), $waitLock, json_encode(array()));
+        return FileAccess::read($this->fullPath(), $waitLock, json_encode([]));
     }
 
     public function read($waitLock = false) {
         $res = $this->read_raw($waitLock);
-        $res['content'] = json_decode($res['content'], true);
+        $res->content = json_decode($res->content, true);
         return $res;
     }
 
@@ -103,12 +103,12 @@ class JSONDatabase {
         $obj = $this->read();
         if (
             !$obj ||
-            array_key_exists('content', $obj) == false ||
-            array_key_exists(strval($key), $obj['content']) == false
+            property_exists($obj, 'content') == false ||
+            array_key_exists(strval($key), $obj->content) == false
         )
             return null;
 
-        $res = array($key => $obj['content'][$key]);
+        $res = [$key => $obj->content[$key]];
         return $res;
     }
 
@@ -126,14 +126,14 @@ class JSONDatabase {
         if (is_primitive($value))
             throw new HTTPException("Invalid value type, got $value_var_type, expected object", 400);
 
-        if ($value !== array() and !array_assoc($value))
+        if ($value !== [] and !array_assoc($value))
             throw new HTTPException('Value cannot be a sequential array', 400);
 
         $key = strval($key);
 
         // set it at the corresponding value
         $obj = $this->read(true);
-        $obj['content'][$key] = json_decode(json_encode($value), true);
+        $obj->content[$key] = json_decode(json_encode($value), true);
         return $this->write($obj);
     }
 
@@ -172,7 +172,7 @@ class JSONDatabase {
 
             $key = strval($keys_decoded[$i]);
 
-            $obj['content'][$key] = $value_decoded[$i];
+            $obj->content[$key] = $value_decoded[$i];
         }
 
         $this->write($obj);
@@ -204,8 +204,8 @@ class JSONDatabase {
         // else set it at the corresponding value
         $obj = $this->read(true);
 
-        $id = $this->newLastKey($obj['content']);
-        $obj['content'][$id] = $value;
+        $id = $this->newLastKey($obj->content);
+        $obj->content[$id] = $value;
 
         $this->write($obj);
 
@@ -216,7 +216,7 @@ class JSONDatabase {
         if (!$this->autoKey)
             throw new HTTPException('Automatic key generation is disabled');
 
-        if ($values !== array() and $values == NULL)
+        if ($values !== [] and $values == NULL)
             throw new HTTPException('null-like value not accepted', 400);
 
         // restricts types to non base variables
@@ -241,11 +241,11 @@ class JSONDatabase {
 
         // decode and add all values
         $values_decoded = $values;
-        $id_array = array();
+        $id_array = [];
         foreach ($values_decoded as $value_decoded) {
-            $id = $this->newLastKey($obj['content']);
+            $id = $this->newLastKey($obj->content);
 
-            $obj['content'][$id] = $value_decoded;
+            $obj->content[$id] = $value_decoded;
 
             array_push($id_array, $id);
         }
@@ -261,12 +261,12 @@ class JSONDatabase {
             throw new HTTPException("Incorrect key type, got $key_var_type, expected string or integer", 400);
 
         $obj = $this->read(true);
-        unset($obj['content'][$key]);
+        unset($obj->content[$key]);
         $this->write($obj);
     }
 
     public function removeBulk($keys) {
-        if ($keys !== array() and $keys == NULL)
+        if ($keys !== [] and $keys == NULL)
             throw new HTTPException('null-like keys not accepted', 400);
 
         if (gettype($keys) !== 'array' or array_assoc($keys))
@@ -284,7 +284,7 @@ class JSONDatabase {
 
         // remove all keys
         foreach ($keys as $key_decoded)
-            unset($obj['content'][$key_decoded]);
+            unset($obj->content[$key_decoded]);
 
         $this->write($obj);
     }
@@ -393,7 +393,7 @@ class JSONDatabase {
         $obj = $this->read();
         $res = [];
 
-        foreach ($obj['content'] as $key => $el) {
+        foreach ($obj->content as $key => $el) {
             $el_root = $el;
 
             $add = true;
@@ -458,15 +458,15 @@ class JSONDatabase {
     public function searchKeys($searchedKeys) {
         $obj = $this->read();
 
-        $res = array();
+        $res = [];
         if (gettype($searchedKeys) != 'array')
             return $res;
 
         foreach ($searchedKeys as $key) {
             $key = strval($key);
 
-            if (array_key_exists($key, $obj['content'])) {
-                $res[$key] = $obj['content'][$key];
+            if (array_key_exists($key, $obj->content)) {
+                $res[$key] = $obj->content[$key];
             }
         }
 
@@ -491,7 +491,7 @@ class JSONDatabase {
             throw new HTTPException('ID must be a string or number', 400);
 
         // object not found
-        if (!array_key_exists($id, $obj['content']) || !check($obj['content'][$id]))
+        if (!array_key_exists($id, $obj->content) || !check($obj->content[$id]))
             throw new HTTPException('ID doesn\'t exist in collection', 400);
 
         // field required
@@ -525,36 +525,36 @@ class JSONDatabase {
         // field not needed for set or push operation (can create fields)
         // missing field in remove doesn't matter since it's gone either way
         if (
-            !isset($obj['content'][$id][$field]) and
+            !isset($obj->content[$id][$field]) and
             ($operation != 'set' and $operation != 'remove' and $operation != 'array-push')
         )
             throw new HTTPException("Field $field doesn't exist in ID $id", 400);
 
         switch ($operation) {
             case 'set':
-                $obj['content'][$id][$field] = $value;
+                $obj->content[$id][$field] = $value;
                 return true;
             case 'remove':
-                unset($obj['content'][$id][$field]);
+                unset($obj->content[$id][$field]);
                 return true;
             case 'append':
                 // check type string
-                if (gettype($obj['content'][$id][$field]) != 'string' or gettype($value) != 'string')
+                if (gettype($obj->content[$id][$field]) != 'string' or gettype($value) != 'string')
                     throw new HTTPException('append requires string values', 400);
 
-                $obj['content'][$id][$field] .= $value;
+                $obj->content[$id][$field] .= $value;
                 return true;
             case 'invert':
                 // check type boolean
-                if (gettype($obj['content'][$id][$field]) != 'boolean')
+                if (gettype($obj->content[$id][$field]) != 'boolean')
                     throw new HTTPException('invert field must be a boolean', 400);
 
-                $obj['content'][$id][$field] = !$obj['content'][$id][$field];
+                $obj->content[$id][$field] = !$obj->content[$id][$field];
                 return true;
             case 'increment':
             case 'decrement':
                 // check type number
-                if (!is_number_like($obj['content'][$id][$field]))
+                if (!is_number_like($obj->content[$id][$field]))
                     throw new HTTPException('increment and decrement fields must be numbers', 400);
 
                 $change = $operation == 'increment' ? 1 : -1;
@@ -569,29 +569,29 @@ class JSONDatabase {
                         throw new HTTPException('increment and decrement values must be numbers', 400);
                 }
 
-                $obj['content'][$id][$field] += $change;
+                $obj->content[$id][$field] += $change;
                 return true;
             case 'array-push':
                 // create it if not here
-                if (!isset($obj['content'][$id][$field]))
-                    $obj['content'][$id][$field] = array();
+                if (!isset($obj->content[$id][$field]))
+                    $obj->content[$id][$field] = [];
 
                 // check if our field array
                 if (
-                    gettype($obj['content'][$id][$field]) != 'array' ||
-                    array_assoc($obj['content'][$id][$field])
+                    gettype($obj->content[$id][$field]) != 'array' ||
+                    array_assoc($obj->content[$id][$field])
                 )
                     throw new HTTPException('array-push field must be an array', 400);
 
-                array_push($obj['content'][$id][$field], $value);
+                array_push($obj->content[$id][$field], $value);
 
                 return true;
 
             case 'array-delete':
                 // check if our field array
                 if (
-                    gettype($obj['content'][$id][$field]) != 'array' ||
-                    array_assoc($obj['content'][$id][$field])
+                    gettype($obj->content[$id][$field]) != 'array' ||
+                    array_assoc($obj->content[$id][$field])
                 )
                     throw new HTTPException('array-delete field must be an array', 400);
 
@@ -599,11 +599,11 @@ class JSONDatabase {
                 if (gettype($value) != 'integer')
                     throw new HTTPException('array-delete value must be a number', 400);
 
-                array_splice($obj['content'][$id][$field], $value, 1);
+                array_splice($obj->content[$id][$field], $value, 1);
 
                 return true;
             case 'array-splice':
-                if (array_assoc($obj['content'][$id][$field]))
+                if (array_assoc($obj->content[$id][$field]))
                     throw new HTTPException('array-splice field must be an array', 400);
 
                 // value must be an array starting with two integers
@@ -616,9 +616,9 @@ class JSONDatabase {
                     throw new HTTPException('Incorrect array-splice options', 400);
 
                 if (count($value) > 2)
-                    array_splice($obj['content'][$id][$field], $value[0], $value[1], $value[2]);
+                    array_splice($obj->content[$id][$field], $value[0], $value[1], $value[2]);
                 else
-                    array_splice($obj['content'][$id][$field], $value[0], $value[1]);
+                    array_splice($obj->content[$id][$field], $value[0], $value[1]);
 
                 return true;
             default:
@@ -663,9 +663,9 @@ class JSONDatabase {
 
         $obj = $this->read();
 
-        $result = array();
-        foreach ($obj['content'] as $key => $value) {
-            $result[$key] = array();
+        $result = [];
+        foreach ($obj->content as $key => $value) {
+            $result[$key] = [];
             foreach ($fields as $field) {
                 if (array_key_exists($field, $value))
                     $result[$key][$field] = $value[$field];
@@ -695,7 +695,7 @@ class JSONDatabase {
         $obj = $this->read();
 
         $result = [];
-        foreach ($obj['content'] as $value) {
+        foreach ($obj->content as $value) {
             // get correct field and skip existing primitive values (faster)
             if (!array_key_exists($field, $value) || in_array($value, $result))
                 continue;
@@ -713,7 +713,35 @@ class JSONDatabase {
         return $result;
     }
 
+
+    // can run with a maximum amount of random entries
+    // (if collection is smaller it's not guaranteed)
+    // (is optional, else it will be all the results)
     public function random($params) {
-        return random($params, $this);
+        $hasMax = array_key_exists('max', $params);
+        $max = $hasMax ? $params['max'] : -1;
+        if ($hasMax && (gettype($max) !== 'integer' || $max < -1))
+            throw new HTTPException('Expected integer >= -1 for the max');
+
+        $hasSeed = array_key_exists('seed', $params);
+        $hasOffset = array_key_exists('offset', $params);
+
+        // offset is relevant only if you get the key
+        if ($hasOffset && !$hasSeed)
+            throw new HTTPException('You can\'t put an offset without a seed');
+
+        // offset validation
+        $offset = $hasOffset ? $params['offset'] : 0;
+        if ($hasOffset && (gettype($offset) !== 'integer' || $offset < 0))
+            throw new HTTPException('Expected integer >= 0 for the offset');
+
+        // seed validation
+        $seed = $hasSeed ? $params['seed'] : false;
+        if ($hasSeed && gettype($seed) !== 'integer')
+            throw new HTTPException('Expected integer for the seed');
+
+        $obj = $this->read();
+
+        return choose_random($obj->content, $seed, $max, $offset);
     }
 }

--- a/php/classes/JSONDatabase.php
+++ b/php/classes/JSONDatabase.php
@@ -107,9 +107,7 @@ class JSONDatabase {
             array_key_exists(strval($key), $obj->content) == false
         )
             return null;
-
-        $res = [$key => $obj->content[$key]];
-        return $res;
+        return $obj->content[$key];
     }
 
     public function set($key, $value) {

--- a/php/classes/JSONDatabase.php
+++ b/php/classes/JSONDatabase.php
@@ -365,6 +365,8 @@ class JSONDatabase {
                         return !array_contains_any($field, $value, $ignoreCase);
                     case 'array-contains-any':
                         return array_contains_any($field, $value, $ignoreCase);
+                    case 'array-contains-all':
+                        return array_contains_all($field, $value, $ignoreCase);
                     case 'array-length':
                     case 'array-length-eq':
                         return count($field) == $value;

--- a/php/classes/read/random.php
+++ b/php/classes/read/random.php
@@ -3,48 +3,17 @@
 require_once './classes/HTTPException.php';
 
 function make_seed() {
-    list($usec, $sec) = explode(' ', microtime());
+    [$usec, $sec] = explode(' ', microtime());
     return intval($sec + $usec * 1000000);
-}
-
-// can run with a maximum amount of random entries
-// (if collection is smaller it's not guaranteed)
-// (is optional, else it will be all the results)
-function random($params, $class) {
-    $hasMax = array_key_exists('max', $params);
-    $max = $hasMax ? $params['max'] : -1;
-    if ($hasMax && (gettype($max) !== 'integer' || $max < -1))
-        throw new HTTPException('Expected integer >= -1 for the max');
-
-    $hasSeed = array_key_exists('seed', $params);
-    $hasOffset = array_key_exists('offset', $params);
-
-    // offset is relevant only if you get the key
-    if ($hasOffset && !$hasSeed)
-        throw new HTTPException('You can\'t put an offset without a seed');
-
-    // offset validation
-    $offset = $hasOffset ? $params['offset'] : 0;
-    if ($hasOffset && (gettype($offset) !== 'integer' || $offset < 0))
-        throw new HTTPException('Expected integer >= 0 for the offset');
-
-    // seed validation
-    $seed = $hasSeed ? $params['seed'] : false;
-    if ($hasSeed && gettype($seed) !== 'integer')
-        throw new HTTPException('Expected integer for the seed');
-
-    $json = $class->read()['content'];
-
-    return choose_random($json, $seed, $max, $offset);
 }
 
 function choose_random($json, $seed = false, $max = -1, $offset = 0) {
     $keys = array_keys($json);
-    $keys_selected = array();
+    $keys_selected = [];
     $keys_length = count($keys);
 
     // return an empty array, can't get more elements
-    if ($offset >= $keys_length) return array();
+    if ($offset >= $keys_length) return [];
 
     if ($max == -1 || $max > $keys_length) $max = $keys_length;
 
@@ -75,7 +44,7 @@ function choose_random($json, $seed = false, $max = -1, $offset = 0) {
     }
 
     // get objects from keys selected
-    $result = array();
+    $result = [];
     foreach ($keys_selected as $k) {
         $key = strval($k);
         $result[$key] = $json[$key];

--- a/php/classes/read/searchArray.php
+++ b/php/classes/read/searchArray.php
@@ -1,42 +1,40 @@
 <?php
 
 function array_contains($array, $value, $ignoreCase = false) {
-    $tmp = false;
-    $tmp_i = 0;
-    while ($tmp_i < count($array) and !$tmp) {
-        if ($ignoreCase) {
-            $tmp = ($ignoreCase ? strcasecmp($array[$tmp_i], $value) : strcmp($array[$tmp_i], $value)) == 0;
-        } else {
-            $tmp = $array[$tmp_i] == $value;
-        }
-        $tmp_i = $tmp_i + 1;
+    for ($tmp_i = 0; $tmp_i < count($array); ++$tmp_i) {
+        $contains = $ignoreCase
+            ? strcasecmp($array[$tmp_i], $value) === 0
+            : $array[$tmp_i] == $value;
+        if ($contains)
+            return true;
     }
-    return $tmp;
+    return false;
 }
 
 function array_contains_any($concernedField, $value, $ignoreCase = false) {
-    $add = false;
+    if (gettype($value) !== 'array')
+        return false;
 
-    if (gettype($value) === 'array') {
-        $tmp = false;
-        $val_i = 0;
-        while ($val_i < count($value) and !$tmp) {
-            $cf_i = 0;
-            while ($cf_i < count($concernedField) && !$tmp) {
-                if ($ignoreCase) {
-                    $tmp = ($ignoreCase ? strcasecmp($concernedField[$cf_i], $value[$val_i]) : strcmp($concernedField[$cf_i], $value[$val_i])) === 0;
-                } else {
-                    $tmp = $concernedField[$cf_i] == $value[$val_i];
-                }
-                $cf_i = $cf_i + 1;
-            }
-            $val_i = $val_i + 1;
+    for ($val_i = 0; $val_i < count($value); ++$val_i) {
+        for ($cf_i = 0; $cf_i < count($concernedField); ++$cf_i) {
+            $contains = $ignoreCase
+                ? strcasecmp($concernedField[$cf_i], $value[$val_i]) === 0
+                : $concernedField[$cf_i] == $value[$val_i];
+            if ($contains)
+                return true;
         }
-
-        $add = $tmp;
-    } else {
-        $add = false;
     }
+    return false;
+}
 
-    return $add;
+function array_contains_all($concernedField, $value, $ignoreCase = false) {
+    if (gettype($value) !== 'array')
+        return false;
+
+    $diff = $ignoreCase
+        ? array_udiff($value, $concernedField, 'strcasecmp')
+        : array_diff($concernedField, $value);
+
+    // if there's no array diff one must be a superset of the other
+    return count($diff) === 0;
 }

--- a/php/files.php
+++ b/php/files.php
@@ -135,7 +135,7 @@ if ($method === 'POST') {
         $imgInfo = getimagesize($absolutePath);
         if ($imgInfo === false) throw new Exception('Not an image');
 
-        header("Content-type: {$imgInfo['mime']}");
+        header("Content-Type: {$imgInfo['mime']}");
         header('Expires: 0');
         header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
         header('Pragma: public');

--- a/php/get.php
+++ b/php/get.php
@@ -68,7 +68,7 @@ switch ($command) {
         break;
     case 'read_raw':
         $res = $db->read_raw();
-        $res = $res['content'];
+        $res = $res->content;
         http_response($res);
         break;
     case 'get':

--- a/php/utils.php
+++ b/php/utils.php
@@ -122,6 +122,7 @@ function remove_dots($path) {
     return $root . implode('/', $ret);
 }
 
+// php 7 compatibility (added in php 8)
 if (!function_exists('str_ends_with')) {
     function str_ends_with(string $haystack, string $needle): bool {
         $needle_len = strlen($needle);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
         specifier: ^4.0.0
         version: 4.0.2
     devDependencies:
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
       chai:
         specifier: ^4.4.1
         version: 4.5.0
@@ -180,6 +183,9 @@ packages:
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/mocha@10.0.10':
+    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
 
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -1504,6 +1510,8 @@ snapshots:
       '@types/mdurl': 2.0.0
 
   '@types/mdurl@2.0.0': {}
+
+  '@types/mocha@10.0.10': {}
 
   aggregate-error@3.1.0:
     dependencies:

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ const __extract_data = async (request) => {
 
 /**
  * Represents a Firestorm Collection
- * @template T
+ * @template T - Type of collection element
  */
 class Collection {
 	/** Name of the Firestorm collection */
@@ -570,8 +570,9 @@ const firestorm = {
 		/**
 		 * Get a file by its path
 		 * @memberof firestorm.files
+		 * @template T - Type of file content
 		 * @param {string} path - The wanted file path
-		 * @returns {Promise<any>} File contents
+		 * @returns {Promise<T>} File contents
 		 */
 		get(path) {
 			return __extract_data(

--- a/src/index.js
+++ b/src/index.js
@@ -224,9 +224,8 @@ class Collection {
 		const res = await this.__get_request("get", {
 			id: key,
 		});
-		const firstKey = Object.keys(res)[0];
-		res[firstKey][ID_FIELD_NAME] = firstKey;
-		res = res[firstKey];
+		// String is more portable than .toString()
+		res[ID_FIELD_NAME] = String(key);
 		return this.__add_methods(res, false);
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ try {
 /**
  * @typedef {Object} SearchOption
  * @property {string} field - The field to be searched for
- * @property {"!=" | "==" | ">=" | "<=" | "<" | ">" | "in" | "includes" | "startsWith" | "endsWith" | "array-contains" | "array-contains-none" | "array-contains-any" | "array-length-eq" | "array-length-df" | "array-length-gt" | "array-length-le" | "array-length-lt" | "array-length-ge"} criteria - Search criteria to filter results
+ * @property {"!=" | "==" | ">=" | "<=" | "<" | ">" | "in" | "includes" | "startsWith" | "endsWith" | "array-contains" | "array-contains-none" | "array-contains-any" | "array-contains-all" | "array-length-eq" | "array-length-df" | "array-length-gt" | "array-length-le" | "array-length-lt" | "array-length-ge"} criteria - Search criteria to filter results
  * @property {string | number | boolean | Array} value - The value to be searched for
  * @property {boolean} [ignoreCase] - Is it case sensitive? (default true)
  */

--- a/tests/tests-get.spec.mjs
+++ b/tests/tests-get.spec.mjs
@@ -177,6 +177,9 @@ describe("GET operations", () => {
 			["array-contains-any", "qualities", ["intelligent", "calm"], ["0", "2"]],
 			["array-contains-any", "qualities", ["intELLIGent", "CALm"], ["0", "2"], true],
 			["array-contains-any", "qualities", ["fast", "flying"], []],
+			["array-contains-all", "qualities", ["intelligent", "strong", "efficient"], ["0"]],
+			["array-contains-all", "qualities", ["intELLIGent", "sTROnG"], ["0"], true],
+			["array-contains-all", "qualities", ["intelligent", "flying"], []],
 			["array-length-eq", "friends", 6, ["0"]],
 			["array-length-eq", "friends", 2, []],
 			["array-length-df", "friends", 6, ["1", "2"]],
@@ -192,7 +195,7 @@ describe("GET operations", () => {
 
 		testArray.forEach(([criteria, field, value, idsFound, ignoreCase]) => {
 			ignoreCase = !!ignoreCase;
-			it(`${criteria} criteria${idsFound.length == 0 ? " (empty result)" : ""}${
+			it(`${criteria} criteria${idsFound.length === 0 ? " (empty result)" : ""}${
 				ignoreCase ? " (case insensitive)" : ""
 			}`, (done) => {
 				base
@@ -208,7 +211,7 @@ describe("GET operations", () => {
 						expect(res).to.be.an("array", "Search result must be an array");
 						expect(res).to.have.lengthOf(
 							idsFound.length,
-							"Expected result have not correct length",
+							"Found result has incorrect length",
 						);
 						expect(res.map((el) => el[firestorm.ID_FIELD])).to.deep.equal(
 							idsFound,

--- a/tests/tests-get.spec.mjs
+++ b/tests/tests-get.spec.mjs
@@ -209,10 +209,7 @@ describe("GET operations", () => {
 					])
 					.then((res) => {
 						expect(res).to.be.an("array", "Search result must be an array");
-						expect(res).to.have.lengthOf(
-							idsFound.length,
-							"Found result has incorrect length",
-						);
+						expect(res).to.have.lengthOf(idsFound.length, "Found result has incorrect length");
 						expect(res.map((el) => el[firestorm.ID_FIELD])).to.deep.equal(
 							idsFound,
 							"Incorrect result search",

--- a/tests/ts-types-test.spec.ts
+++ b/tests/ts-types-test.spec.ts
@@ -7,6 +7,7 @@ import firestorm from "..";
 
 // let's declare an interface for our collection
 interface User {
+	id: string;
 	name: string;
 }
 
@@ -19,9 +20,9 @@ interface UserWithMethods extends User {
 }
 
 // where the method implementation goes in the addMethods
-const usersWithMethods = firestorm.collection<UserWithMethods>("users", (col) => {
-	col.getNameAsLowerCase = (): string => col.name.toLowerCase();
-	return col;
+const usersWithMethods = firestorm.collection<UserWithMethods>("users", (el) => {
+	el.getNameAsLowerCase = (): string => el.name.toLowerCase();
+	return el;
 });
 
 // we can use the methods in all results...
@@ -35,6 +36,7 @@ usersWithMethods.select({ fields: ["name", "family"] }); // getNameAsLowerCase n
 
 // 1. search through a collection
 interface User {
+	id: string;
 	name: string;
 	age: number;
 	sex: "female" | "male" | "other";
@@ -59,25 +61,24 @@ users.search([
 	{ field: "emails", criteria: "array-contains-any", value: ["aha@domain.net", "ehe@domain.net"] },
 ]);
 
-// 2. collections can interfere with each other
+// 2. collections can interface with each other
 interface Family {
+	id: string;
 	parents: User[];
 	children: User[];
 	getDad(): Promise<User>;
 	getMom(): Promise<User>;
 }
 
-firestorm.collection<Family>("families", (col) => {
-	col.getDad = (): Promise<User> =>
+firestorm.collection<Family>("families", (el) => {
+	el.getDad = (): Promise<User> =>
 		users.search([
-			//! TODO - needs clarification
-			// firestorm.ID_FIELD refers to id of the 'asked object' of the collection
 			// === family id
-			{ field: "family", criteria: "==", value: firestorm.ID_FIELD },
+			{ field: "family", criteria: "==", value: el[firestorm.ID_FIELD] },
 			{ field: "sex", criteria: "==", value: "male" },
 		])[0];
 
-	return col;
+	return el;
 });
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -348,7 +348,7 @@ declare class Collection<T> {
 }
 
 /** Value for the ID field when searching content */
-export const ID_FIELD: string;
+export const ID_FIELD: "id";
 
 /**
  * Change or get the current Firestorm address

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -18,7 +18,7 @@ export type StringCriteria =
 	| ">=" /** String value length is greater than or equal to the provided value */
 	| "in" /** String value is in the given array */
 	| "includes" /** String value includes the provided value */
-	| "contains" /** Same as "includes" */
+	| "contains" /** Alias of "includes" */
 	| "startsWith" /** String value starts with the provided value */
 	| "endsWith"; /** String value ends with the provided value */
 
@@ -26,6 +26,7 @@ export type ArrayCriteria =
 	| "array-contains" /** Value is in the given array */
 	| "array-contains-none" /** No value of the array is in the given array */
 	| "array-contains-any" /** Any value of the array is in the given array */
+	| "array-contains-all" /** Every value of the array is in the given array */
 	| "array-length-eq" /** Array length is equal to the provided value */
 	| "array-length-df" /** Array length is different from the provided value */
 	| "array-length-gt" /** Array length is greater than the provided value */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -182,7 +182,7 @@ export type Settable<T> = Addable<T> & {
 
 /**
  * Represents a Firestorm Collection
- * @template T Type of collection element
+ * @template T - Type of collection element
  */
 declare class Collection<T> {
 	/** Name of the Firestorm collection */
@@ -387,10 +387,11 @@ export function table<T>(table: string): Collection<T>;
 export declare const files: {
 	/**
 	 * Get a file by its path
+	 * @template T - Type of file content
 	 * @param path - The wanted file path
 	 * @returns File contents
 	 */
-	get(path: string): Promise<any>;
+	get<T>(path: string): Promise<T>;
 
 	/**
 	 * Upload a file


### PR DESCRIPTION
(from changelog)

### Added

- `array-contains-all` option for array fields.

### Changed

- Changed PHP file representation from an associative array to a strongly-typed FileObject class.
- Reduced payload size for `Collection.get`.
- Use modern async/await for client code (supported in all major browers/Node.js since 2017).
- Made `firestorm.files.get` a generic method for increased type safety.

### Fixed

- Fixed `ID_FIELD` TypeScript type.