### PR TITLE
[Add] limit search option

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint code
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: pnpm install
+      - run: pnpm run lint:check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `array-contains-all` option for array fields.
+- `Collection.search` option now has a `limit` option, compatible with `random` to restrict the number of elements displayed
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ johnDoe.hello(); // "John Doe says hello!"
 
 There are more options available than the Firestore `where` command, allowing you to get better and faster search results.
 
-The search method can take one or more options to filter entries in a collection. A search option takes a `field` with a `criteria` and compares it to a `value`. You can also use the boolean `ignoreCase` option for string values. Available criteria depends on the field type.
+The search method can take one or more options to filter entries in a collection. A search option takes a `field` with a `criteria` and compares it to a `value`. You can also use the boolean `ignoreCase` option for string values and the `limit` option to restrict the number of results returned. Available criteria depends on the field type.
 
 | Criteria                | Types allowed                 | Description                                                     |
 | ----------------------- | ----------------------------- | --------------------------------------------------------------- |
@@ -127,6 +127,16 @@ The search method can take one or more options to filter entries in a collection
 | `'array-length-gt'`     | `number`                      | Entry field's array size is greater than your value             |
 | `'array-length-le'`     | `number`                      | Entry field's array size is lower or equal to your value        |
 | `'array-length-ge'`     | `number`                      | Entry field's array size is greater or equal to your value      |
+
+### Search Option Properties
+
+| Property    | Type      | Description                                                                 |
+| ----------- | --------- | --------------------------------------------------------------------------- |
+| `field`     | `string`  | The field path to search in (supports dot notation for nested fields)      |
+| `criteria`  | `string`  | The comparison criteria to use (see table above)                           |
+| `value`     | `any`     | The value to compare against                                                |
+| `ignoreCase`| `boolean` | Whether to ignore case sensitivity for string comparisons (default: false) |
+| `limit`     | `number`  | Maximum number of results to return (lowest limit is chosen if multiple)   |
 
 ## Edit field options
 

--- a/README.md
+++ b/README.md
@@ -33,17 +33,20 @@ The JavaScript [index.js](./src/index.js) file is simply an [Axios](https://www.
 
 ## JavaScript setup
 
-First, set your API address (and your writing token if needed) using the `address()` and `token()` functions:
+First, set your API address (and your writing token if needed) using the `address()` and `token()` setters. If you need to later retrieve these values, you can use the same functions as getters with no parameters:
 
 ```js
 // only needed in Node.js; including the script tag in a browser is enough otherwise.
 const firestorm = require("firestorm-db");
 
-firestorm.address("http://example.com/path/to/firestorm/root/");
+firestorm.address("https://example.com/path/to/firestorm/root/");
 
 // only necessary if you want to write or access private collections
 // must match token stored in tokens.php file
 firestorm.token("my_secret_token_probably_from_an_env_file");
+
+const address = firestorm.address();
+// returns "https://example.com/path/to/firestorm/root"
 ```
 
 Now you can use Firestorm to its full potential.
@@ -67,7 +70,7 @@ const userCollection = firestorm.collection("users", (el) => {
 
 // all methods return promises
 const johnDoe = await userCollection.get(123456789);
-// gives { name: "John Doe", hello: Function }
+// returns { name: "John Doe", hello: Function }
 
 johnDoe.hello(); // "John Doe says hello!"
 ```
@@ -153,7 +156,7 @@ Edit objects have an element `id`, a `field` to edit, an `operation` specifying 
 | `array-delete` | Yes         | `number`                 | Removes an array element by index.                                                                                                     |
 | `array-splice` | Yes         | `[number, number, any?]` | Last argument is optional. Check the PHP [array_splice](https://www.php.net/manual/function.array-splice) documentation for more info. |
 
-Various other methods and constants exist in the JavaScript client, which will make more sense once you learn what's actually happening behind the scenes.
+Various other methods and constants exist in the JavaScript client, which make more sense once you learn what's actually happening behind the scenes.
 
 # PHP Backend
 
@@ -161,7 +164,7 @@ Firestorm's PHP files handle files, read, and writes, through `GET` and `POST` r
 
 ## PHP setup
 
-The server-side files to handle requests can be found and copied to your hosting platform [here](./php/). The two files that need editing are `tokens.php` and `config.php`.
+The server-side files to handle requests can be found and copied to your hosting platform [here](./php/), which are compatible with both PHP 7 and 8. Two files will need editing: `tokens.php` and `config.php`.
 
 - `tokens.php` contains writing tokens declared in a `$db_tokens` array. These correspond to the tokens used with `firestorm.token()` in the JavaScript client.
 - `config.php` stores all of your collections. This file needs to declare a `$database_list` associative array of `JSONDatabase` instances.
@@ -380,7 +383,7 @@ Each operation type requests a different file. In the JavaScript client, the cor
 
 - Read requests are `GET` requests sent to `<your_address_here>/get.php`.
 - Write requests are `POST` requests sent to `<your_address_here>/post.php` with JSON data.
-- File requests are sent to `<your_address_here>/files.php` with form data.
+- File requests are `POST` requests sent to `<your_address_here>/files.php` with form data.
 
 The first keys in a Firestorm request will always be the same regardless of its type, and further keys will depend on the specific method:
 
@@ -404,9 +407,10 @@ Fatal error:
 Allowed memory size of 134217728 bytes exhausted (tried to allocate 32360168 bytes)
 ```
 
-If you encounter a memory allocation issue, simply change the memory limit in `/etc/php/7.4/apache2/php.ini` to be bigger:
+If you encounter a memory allocation issue, simply change the memory limit in `/etc/php/<php_version_here>/apache2/php.ini` to be bigger:
 
 ```ini
+; Default is 128M
 memory_limit = 256M
 ```
 
@@ -420,7 +424,7 @@ Firestorm ships with TypeScript support out of the box.
 
 Collections in TypeScript take a generic parameter `T`, which is the type of each element in the collection. If you aren't using a relational collection, this can simply be set to `any`.
 
-The generic parameter must contain an `ID_FIELD` imported from Firestorm (unless you're using a non-relational collection).
+The generic parameter must contain a string field named `ID_FIELD` imported from Firestorm (unless you're using a non-relational collection).
 
 ```ts
 import firestorm from "firestorm-db";
@@ -428,7 +432,7 @@ firestorm.address("ADDRESS_VALUE");
 
 interface User {
     // An ID field is required by a generic constraint
-    // unless the collection is non-relational
+    // (unless the collection is non-relational)
     [firestorm.ID_FIELD]: string;
     name: string;
     password: string;
@@ -441,7 +445,7 @@ const johnDoe = await userCollection.get(123456789);
 // type: { [ID_FIELD]: string, name: string, password: string, pets: string[] }
 ```
 
-Injected methods should also be stored in this interface. They'll get filtered out from write operations to prevent false positives:
+Injected methods should also be stored in this interface. They'll be filtered out from write operations correctly, so don't worry about potential typing inaccuracies:
 
 ```ts
 import firestorm from "firestorm-db";

--- a/README.md
+++ b/README.md
@@ -130,13 +130,12 @@ The search method can take one or more options to filter entries in a collection
 
 ### Search Option Properties
 
-| Property    | Type      | Description                                                                 |
-| ----------- | --------- | --------------------------------------------------------------------------- |
+| Property    | Type      | Description                                                                |
+| ----------- | --------- | -------------------------------------------------------------------------- |
 | `field`     | `string`  | The field path to search in (supports dot notation for nested fields)      |
 | `criteria`  | `string`  | The comparison criteria to use (see table above)                           |
-| `value`     | `any`     | The value to compare against                                                |
+| `value`     | `any`     | The value to compare against                                               |
 | `ignoreCase`| `boolean` | Whether to ignore case sensitivity for string comparisons (default: false) |
-| `limit`     | `number`  | Maximum number of results to return (lowest limit is chosen if multiple)   |
 
 ## Edit field options
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,14 @@
     "overrides": {
       "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5",
       "diff@>=6.0.0 <8.0.3": ">=8.0.3",
-      "serialize-javascript@<=7.0.2": ">=7.0.3"
+      "serialize-javascript@<=7.0.2": ">=7.0.3",
+      "handlebars@>=4.0.0 <=4.7.8": ">=4.7.9",
+      "serialize-javascript@<7.0.5": ">=7.0.5",
+      "brace-expansion@<1.1.13": ">=1.1.13",
+      "brace-expansion@>=2.0.0 <2.0.3": ">=2.0.3",
+      "handlebars@>=4.0.0 <4.7.9": ">=4.7.9",
+      "picomatch@<2.3.2": ">=2.3.2",
+      "handlebars@>=4.6.0 <=4.7.8": ">=4.7.9"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "php:start": "node tests/php_setup.mjs",
     "php:stop": "sh tests/php_server_kill.sh",
-    "php:tests": "pnpm php:stop ; pnpm php:start && pnpm js:tests ; pnpm php:stop",
+    "php:tests": "pnpm php:stop ; pnpm php:start && pnpm js:tests ; e=$? ; pnpm php:stop ; exit $e",
     "js:tests": "mocha tests/**/tests-setup.spec.mjs tests/**/*.spec.mjs",
     "docker:build": "bash docker/docker_image_build.bash",
     "docker:alive": "bash docker/docker_image_alive.bash",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "doc:gen": "jsdoc src/index.js -c jsdoc.json -R README.md -t ./node_modules/docdash -d out",
     "doc:watch": "nodemon -x pnpm doc:gen --watch src/index.js --watch jsdoc.json --watch README.md",
     "types:gen": "npx tsc",
-    "lint:prettier": "prettier \"{,!(node_modules)/**/}*.{cjs,mjs,js,ts}\" --config .prettierrc --write",
+    "lint:write": "prettier \"{,!(node_modules)/**/}*.{cjs,mjs,js,ts}\" --config .prettierrc --write",
+    "lint:check": "prettier \"{,!(node_modules)/**/}*.{cjs,mjs,js,ts}\" --config .prettierrc --check",
     "coverage": "pnpm php:stop ; pnpm php:start && nyc --reporter=text mocha tests/**/*.spec.js; pnpm php:stop"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "axios": "^1.11.0",
+    "axios": ">=1.13.6",
     "form-data": "^4.0.4"
   },
   "devDependencies": {
@@ -65,7 +65,8 @@
   "pnpm": {
     "overrides": {
       "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5",
-      "serialize-javascript@>=6.0.0 <6.0.2": ">=6.0.2"
+      "diff@>=6.0.0 <8.0.3": ">=8.0.3",
+      "serialize-javascript@<=7.0.2": ">=7.0.3"
     }
   }
 }

--- a/php/classes/JSONDatabase.php
+++ b/php/classes/JSONDatabase.php
@@ -404,9 +404,14 @@ class JSONDatabase {
     }
 
     public function search($conditions, $random = false, $limit = false) {
+        $has_limit = false;
+        if(gettype($limit) === 'integer' && $limit > 0)
+            $has_limit = true;
+        else if($limit !== false)
+            throw new HTTPException('search option limit must be a positive integer');
+
         $obj = $this->read();
         $res = [];
-        $has_limit = $limit !== false && is_int($limit) && $limit > 0;
 
         foreach ($obj->content as $key => $el) {
             $el_root = $el;

--- a/php/classes/JSONDatabase.php
+++ b/php/classes/JSONDatabase.php
@@ -403,9 +403,10 @@ class JSONDatabase {
         return false;
     }
 
-    public function search($conditions, $random = false) {
+    public function search($conditions, $random = false, $limit = false) {
         $obj = $this->read();
         $res = [];
+        $has_limit = $limit !== false && is_int($limit) && $limit > 0;
 
         foreach ($obj->content as $key => $el) {
             $el_root = $el;
@@ -453,6 +454,10 @@ class JSONDatabase {
             // if all conditions are met, we can add the value to our output
             if ($add)
                 $res[$key] = $el_root;
+
+            // only stop early if results will not be ordered randomly 
+            if($has_limit && $random === false && count($res) >= $limit)
+                break;
         }
 
         if ($random !== false) {
@@ -463,7 +468,8 @@ class JSONDatabase {
                     throw new HTTPException('Seed not an integer value for random search result');
                 $seed = intval($rawSeed);
             }
-            $res = choose_random($res, $seed);
+            // apply limit during random selection to avoid unnecessary processing
+            $res = choose_random($res, $seed, $has_limit ? $limit : -1);
         }
 
         return $res;

--- a/php/get.php
+++ b/php/get.php
@@ -87,11 +87,12 @@ switch ($command) {
     case 'search':
         $search = check_key_json('search', $inputJSON, false);
         $random = check_key_json('random', $inputJSON, false);
+        $limit = check_key_json('limit', $inputJSON, false);
 
         if (!$search)
             http_error(400, 'No search provided');
 
-        $result = $db->search($search, $random);
+        $result = $db->search($search, $random, $limit);
 
         http_response(stringifier($result));
         break;

--- a/php/get.php
+++ b/php/get.php
@@ -131,7 +131,8 @@ switch ($command) {
 
 http_message(400, 'Bad request');
 
-
+} catch(HTTPException $e) {
+    http_error($e->getCode(), $e->getMessage());
 } catch(Exception $e) {
-    http_error(500, $e->getMessage());
+    http_error(400, $e->getMessage());
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,16 @@ settings:
 
 overrides:
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
-  serialize-javascript@>=6.0.0 <6.0.2: '>=6.0.2'
+  diff@>=6.0.0 <8.0.3: '>=8.0.3'
+  serialize-javascript@<=7.0.2: '>=7.0.3'
 
 importers:
 
   .:
     dependencies:
       axios:
-        specifier: ^1.11.0
-        version: 1.11.0
+        specifier: '>=1.13.6'
+        version: 1.13.6
       form-data:
         specifier: ^4.0.4
         version: 4.0.4
@@ -124,14 +125,6 @@ packages:
   '@babel/types@7.26.10':
     resolution: {integrity: sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==}
     engines: {node: '>=6.9.0'}
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -258,20 +251,28 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -432,8 +433,8 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   dmd@7.1.1:
@@ -562,8 +563,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -581,6 +582,10 @@ packages:
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   fromentries@1.3.2:
@@ -763,12 +768,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   js2xmlparser@4.0.2:
@@ -840,8 +845,8 @@ packages:
     resolution: {integrity: sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==}
     deprecated: This package is deprecated. Use destructuring assignment syntax instead.
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -874,8 +879,8 @@ packages:
       '@types/markdown-it': '*'
       markdown-it: '*'
 
-  markdown-it@14.1.0:
-    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
   marked@4.3.0:
@@ -910,15 +915,15 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
@@ -1062,9 +1067,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -1107,9 +1109,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -1119,8 +1118,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.4:
+    resolution: {integrity: sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==}
+    engines: {node: '>=20.0.0'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -1232,8 +1232,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  underscore@1.13.7:
-    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -1431,12 +1431,6 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -1451,7 +1445,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -1475,7 +1469,7 @@ snapshots:
 
   '@jsdoc/salty@0.2.9':
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1548,26 +1542,32 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.11.0:
+  axios@1.13.6:
     dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.4
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bluebird@3.7.2: {}
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -1606,7 +1606,7 @@ snapshots:
 
   catharsis@0.9.0:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   chai@5.2.1:
     dependencies:
@@ -1711,7 +1711,7 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  diff@7.0.0: {}
+  diff@8.0.4: {}
 
   dmd@7.1.1:
     dependencies:
@@ -1818,7 +1818,7 @@ snapshots:
 
   flat@5.0.2: {}
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.15.11: {}
 
   foreground-child@2.0.0:
     dependencies:
@@ -1831,6 +1831,14 @@ snapshots:
       signal-exit: 4.1.0
 
   form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -1876,7 +1884,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -1885,7 +1893,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.1.1
+      minimatch: 10.2.4
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -1895,7 +1903,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -2024,12 +2032,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.1:
+  js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2077,13 +2085,13 @@ snapshots:
       escape-string-regexp: 2.0.0
       js2xmlparser: 4.0.2
       klaw: 3.0.0
-      markdown-it: 14.1.0
-      markdown-it-anchor: 8.6.7(@types/markdown-it@14.1.2)(markdown-it@14.1.0)
+      markdown-it: 14.1.1
+      markdown-it-anchor: 8.6.7(@types/markdown-it@14.1.2)(markdown-it@14.1.1)
       marked: 4.3.0
       mkdirp: 1.0.4
       requizzle: 0.2.4
       strip-json-comments: 3.1.1
-      underscore: 1.13.7
+      underscore: 1.13.8
 
   jsesc@3.1.0: {}
 
@@ -2113,7 +2121,7 @@ snapshots:
 
   lodash.omit@4.5.0: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -2138,12 +2146,12 @@ snapshots:
     dependencies:
       semver: 7.7.1
 
-  markdown-it-anchor@8.6.7(@types/markdown-it@14.1.2)(markdown-it@14.1.0):
+  markdown-it-anchor@8.6.7(@types/markdown-it@14.1.2)(markdown-it@14.1.1):
     dependencies:
       '@types/markdown-it': 14.1.2
-      markdown-it: 14.1.0
+      markdown-it: 14.1.1
 
-  markdown-it@14.1.0:
+  markdown-it@14.1.1:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -2161,7 +2169,7 @@ snapshots:
       array-differ: 1.0.0
       array-union: 1.0.2
       arrify: 1.0.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
 
   mdurl@2.0.0: {}
 
@@ -2178,17 +2186,17 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  minimatch@10.1.1:
+  minimatch@10.2.4:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      brace-expansion: 5.0.5
 
-  minimatch@3.1.2:
+  minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
-  minimatch@9.0.5:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 
@@ -2205,17 +2213,17 @@ snapshots:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
       debug: 4.4.0(supports-color@8.1.1)
-      diff: 7.0.0
+      diff: 8.0.4
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
       glob: 10.5.0
       he: 1.2.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       log-symbols: 4.1.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.4
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
       workerpool: 9.3.3
@@ -2348,10 +2356,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   readdirp@4.1.2: {}
 
   recursive-copy@2.0.14:
@@ -2376,7 +2380,7 @@ snapshots:
 
   requizzle@0.2.4:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   resolve-from@5.0.0: {}
 
@@ -2394,15 +2398,11 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-buffer@5.2.1: {}
-
   semver@6.3.1: {}
 
   semver@7.7.1: {}
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.4: {}
 
   set-blocking@2.0.0: {}
 
@@ -2477,7 +2477,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
 
   to-regex-range@5.0.1:
     dependencies:
@@ -2498,7 +2498,7 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
-  underscore@1.13.7: {}
+  underscore@1.13.8: {}
 
   update-browserslist-db@1.1.3(browserslist@4.24.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,13 @@ overrides:
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   diff@>=6.0.0 <8.0.3: '>=8.0.3'
   serialize-javascript@<=7.0.2: '>=7.0.3'
+  handlebars@>=4.0.0 <=4.7.8: '>=4.7.9'
+  serialize-javascript@<7.0.5: '>=7.0.5'
+  brace-expansion@<1.1.13: '>=1.1.13'
+  brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
+  handlebars@>=4.0.0 <4.7.9: '>=4.7.9'
+  picomatch@<2.3.2: '>=2.3.2'
+  handlebars@>=4.6.0 <=4.7.8: '>=4.7.9'
 
 importers:
 
@@ -254,21 +261,12 @@ packages:
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -379,9 +377,6 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   config-master@3.1.0:
     resolution: {integrity: sha512-n7LBL1zBzYdTpF1mx5DNcZnZn05CWIdsdvtPL4MosvqbBUK3Rq6VWEtGUuF3Y0s9/CIhMejezqlSkP6TnCJ/9g==}
@@ -645,8 +640,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -1030,9 +1025,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -1118,8 +1113,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@7.0.4:
-    resolution: {integrity: sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
 
   set-blocking@2.0.0:
@@ -1550,20 +1545,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   bluebird@3.7.2: {}
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -1673,8 +1657,6 @@ snapshots:
 
   commondir@1.0.1: {}
 
-  concat-map@0.0.1: {}
-
   config-master@3.1.0:
     dependencies:
       walk-back: 2.0.1
@@ -1719,7 +1701,7 @@ snapshots:
       cache-point: 3.0.1
       common-sequence: 3.0.0
       file-set: 5.2.2
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       marked: 4.3.0
       walk-back: 5.1.1
 
@@ -1913,7 +1895,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -2178,7 +2160,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   mime-db@1.52.0: {}
 
@@ -2192,11 +2174,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 5.0.5
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -2223,7 +2205,7 @@ snapshots:
       minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
       workerpool: 9.3.3
@@ -2330,7 +2312,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@4.0.4: {}
 
   pify@2.3.0: {}
 
@@ -2402,7 +2384,7 @@ snapshots:
 
   semver@7.7.1: {}
 
-  serialize-javascript@7.0.4: {}
+  serialize-javascript@7.0.5: {}
 
   set-blocking@2.0.0: {}
 

--- a/src/index.js
+++ b/src/index.js
@@ -257,7 +257,7 @@ class Collection {
 	 */
 	async search(options, random = false, limit = undefined) {
 		if (!Array.isArray(options)) throw new TypeError("searchOptions shall be an array");
-		if (typeof limit !== "number" || limit <= 0 || !Number.isInteger(limit))
+		if (limit !== undefined && (typeof limit !== "number" || limit <= 0 || !Number.isInteger(limit)))
 			throw new TypeError(`${JSON.stringify(limit)} search option limit must be a positive integer`);
 				
 		options.forEach((option) => {

--- a/src/index.js
+++ b/src/index.js
@@ -261,16 +261,33 @@ class Collection {
 	 */
 	async search(options, resultOptions = undefined) {
 		if (!Array.isArray(options)) throw new TypeError("searchOptions shall be an array");
-		if (resultOptions !== undefined && typeof(resultOptions) !== "number" && typeof(resultOptions) !== "boolean"
-			&& typeof(resultOptions) !== "object") throw new TypeError("Incorrect search result options");
-		
+		if (
+			resultOptions !== undefined &&
+			typeof resultOptions !== "number" &&
+			typeof resultOptions !== "boolean" &&
+			typeof resultOptions !== "object"
+		)
+			throw new TypeError("Incorrect search result options");
+
 		const { random = false, limit = undefined } = resultOptions || {};
 
-		if (limit !== undefined && (typeof limit !== "number" || limit <= 0 || !Number.isInteger(limit)))
-			throw new TypeError(`${JSON.stringify(limit)} search option limit must be a positive integer`);
+		if (
+			limit !== undefined &&
+			(typeof limit !== "number" || limit <= 0 || !Number.isInteger(limit))
+		)
+			throw new TypeError(
+				`${JSON.stringify(limit)} search option limit must be a positive integer`,
+			);
 
-		if (random !== undefined && random !== false && random !== true && (typeof random !== "number" || !Number.isInteger(random)))
-			throw new TypeError(`${JSON.stringify(random)} search option random must be a boolean or an integer`);
+		if (
+			random !== undefined &&
+			random !== false &&
+			random !== true &&
+			(typeof random !== "number" || !Number.isInteger(random))
+		)
+			throw new TypeError(
+				`${JSON.stringify(random)} search option random must be a boolean or an integer`,
+			);
 
 		options.forEach((option) => {
 			if (option.field === undefined || option.criteria === undefined || option.value === undefined)
@@ -293,7 +310,7 @@ class Collection {
 			params.limit = limit;
 		}
 
-		if(random !== undefined && random !== false) {
+		if (random !== undefined && random !== false) {
 			params.random = parseInt(random);
 			if (random === true) {
 				params.random = {};

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ try {
  * @property {"!=" | "==" | ">=" | "<=" | "<" | ">" | "in" | "includes" | "startsWith" | "endsWith" | "array-contains" | "array-contains-none" | "array-contains-any" | "array-contains-all" | "array-length-eq" | "array-length-df" | "array-length-gt" | "array-length-le" | "array-length-lt" | "array-length-ge"} criteria - Search criteria to filter results
  * @property {string | number | boolean | Array} value - The value to be searched for
  * @property {boolean} [ignoreCase] - Is it case sensitive? (default true)
+ * @property {number} [limit] - Maximum number of results to return (optional)
  */
 
 /**
@@ -251,11 +252,14 @@ class Collection {
 	 * Search through the collection
 	 * @param {SearchOption[]} options - Array of search options
 	 * @param {boolean | number} [random] - Random result seed, disabled by default, but can activated with true or a given seed
+	 * @param {number?} [limit] - Maximum number of results to return (optional, overridden by individual search option limits)
 	 * @returns {Promise<T[]>} The found elements
 	 */
-	async search(options, random = false) {
+	async search(options, random = false, limit = undefined) {
 		if (!Array.isArray(options)) throw new TypeError("searchOptions shall be an array");
-
+		if (typeof limit !== "number" || limit <= 0 || !Number.isInteger(limit))
+			throw new TypeError(`${JSON.stringify(limit)} search option limit must be a positive integer`);
+				
 		options.forEach((option) => {
 			if (option.field === undefined || option.criteria === undefined || option.value === undefined)
 				throw new TypeError("Missing fields in searchOptions array");
@@ -272,6 +276,10 @@ class Collection {
 		const params = {
 			search: options,
 		};
+
+		if (limit !== undefined) {
+			params.limit = limit;
+		}
 
 		if (random !== false) {
 			if (random === true) {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,12 @@ try {
  * @property {"!=" | "==" | ">=" | "<=" | "<" | ">" | "in" | "includes" | "startsWith" | "endsWith" | "array-contains" | "array-contains-none" | "array-contains-any" | "array-contains-all" | "array-length-eq" | "array-length-df" | "array-length-gt" | "array-length-le" | "array-length-lt" | "array-length-ge"} criteria - Search criteria to filter results
  * @property {string | number | boolean | Array} value - The value to be searched for
  * @property {boolean} [ignoreCase] - Is it case sensitive? (default true)
- * @property {number} [limit] - Maximum number of results to return (optional)
+ */
+
+/**
+ * @typedef {Object} SearchResultOptions
+ * @property {(boolean | number)?} [random] - Random result seed, disabled by default, but can activated with true or a given seed
+ * @property {number?} [limit] - Maximum number of results to return
  */
 
 /**
@@ -251,15 +256,22 @@ class Collection {
 	/**
 	 * Search through the collection
 	 * @param {SearchOption[]} options - Array of search options
-	 * @param {boolean | number} [random] - Random result seed, disabled by default, but can activated with true or a given seed
-	 * @param {number?} [limit] - Maximum number of results to return (optional, overridden by individual search option limits)
+	 * @param {(boolean|number|SearchResultOptions)?} [resultOptions] - Search result options
 	 * @returns {Promise<T[]>} The found elements
 	 */
-	async search(options, random = false, limit = undefined) {
+	async search(options, resultOptions = undefined) {
 		if (!Array.isArray(options)) throw new TypeError("searchOptions shall be an array");
+		if (resultOptions !== undefined && typeof(resultOptions) !== "number" && typeof(resultOptions) !== "boolean"
+			&& typeof(resultOptions) !== "object") throw new TypeError("Incorrect search result options");
+		
+		const { random = false, limit = undefined } = resultOptions || {};
+
 		if (limit !== undefined && (typeof limit !== "number" || limit <= 0 || !Number.isInteger(limit)))
 			throw new TypeError(`${JSON.stringify(limit)} search option limit must be a positive integer`);
-				
+
+		if (random !== undefined && random !== false && random !== true && (typeof random !== "number" || !Number.isInteger(random)))
+			throw new TypeError(`${JSON.stringify(random)} search option random must be a boolean or an integer`);
+
 		options.forEach((option) => {
 			if (option.field === undefined || option.criteria === undefined || option.value === undefined)
 				throw new TypeError("Missing fields in searchOptions array");
@@ -281,14 +293,12 @@ class Collection {
 			params.limit = limit;
 		}
 
-		if (random !== false) {
+		if(random !== undefined && random !== false) {
+			params.random = parseInt(random);
 			if (random === true) {
 				params.random = {};
 			} else {
 				const seed = parseInt(random);
-				if (isNaN(seed))
-					throw new TypeError("random takes as parameter true, false or an integer value");
-
 				params.random = { seed };
 			}
 		}

--- a/tests/tests-get.spec.mjs
+++ b/tests/tests-get.spec.mjs
@@ -341,6 +341,42 @@ describe("GET operations", () => {
 		});
 	});
 
+	describe("search(searchOptions) with limit", () => {
+		it("limits the number of results returned", (done) => {
+			base
+				.search([
+					{
+						criteria: "includes",
+						field: "name",
+						value: "Joy",
+					},
+				], false, 1)
+				.then((res) => {
+					expect(res).to.be.an("array", "Search result must be an array");
+					expect(res).to.have.lengthOf(1, "Should return exactly 1 result due to limit");
+					expect(res[0][firestorm.ID_FIELD]).to.be.oneOf(["0", "1", "2"], "Should be one of the matching IDs");
+					done();
+				})
+				.catch(done);
+		});
+
+		it("validates limit must be a positive integer", (done) => {
+			base
+				.search([
+					{
+						criteria: "includes",
+						field: "name",
+						value: "Joy",
+					},
+				], false, 1)
+				.then(() => done(new Error("Should have thrown an error for invalid limit")))
+				.catch((err) => {
+					expect(err.message).to.include("limit must be a positive integer");
+					done();
+				});
+		});
+	});
+
 	describe("select(selectOptions)", () => {
 		it("requires a fields field", (done) => {
 			base

--- a/tests/tests-get.spec.mjs
+++ b/tests/tests-get.spec.mjs
@@ -4,7 +4,8 @@ import crypto from "crypto";
 import { expect } from "chai";
 
 import firestorm from "../src/index.js";
-import { base, content, resetDatabaseContent } from "./tests.env.mjs";
+import { base, content, resetDatabaseContent, ADDRESS, TOKEN } from "./tests.env.mjs";
+import { request } from "http";
 
 describe("GET operations", () => {
 	before(async () => await resetDatabaseContent());
@@ -274,7 +275,7 @@ describe("GET operations", () => {
 		});
 
 		// undefined works because random becomes default parameter false, so false works too
-		const incorrect = ["gg", "", { random: "gg"}, { random: ""}];
+		const incorrect = ["gg", "", { random: "gg" }, { random: "" }];
 		incorrect.forEach((incor) => {
 			it(`${JSON.stringify(incor)} seed rejects`, (done) => {
 				base
@@ -294,7 +295,7 @@ describe("GET operations", () => {
 			});
 		});
 
-		[true, { random: true }].forEach(trueval => {
+		[true, { random: true }].forEach((trueval) => {
 			it(`${JSON.stringify(trueval)} seed succeeds`, (done) => {
 				base
 					.search(
@@ -346,19 +347,25 @@ describe("GET operations", () => {
 	describe("search(searchOptions) with limit", () => {
 		it("limits the number of results returned", (done) => {
 			base
-				.search([
+				.search(
+					[
+						{
+							criteria: "includes",
+							field: "name",
+							value: "Joy",
+						},
+					],
 					{
-						criteria: "includes",
-						field: "name",
-						value: "Joy",
+						limit: 1,
 					},
-				], {
-					limit: 1,
-				})
+				)
 				.then((res) => {
 					expect(res).to.be.an("array", "Search result must be an array");
 					expect(res).to.have.lengthOf(1, "Should return exactly 1 result due to limit");
-					expect(res[0][firestorm.ID_FIELD]).to.be.oneOf(["0", "1", "2"], "Should be one of the matching IDs");
+					expect(res[0][firestorm.ID_FIELD]).to.be.oneOf(
+						["0", "1", "2"],
+						"Should be one of the matching IDs",
+					);
 					done();
 				})
 				.catch(done);
@@ -366,20 +373,119 @@ describe("GET operations", () => {
 
 		it("validates limit must be a positive integer", (done) => {
 			base
-				.search([
+				.search(
+					[
+						{
+							criteria: "includes",
+							field: "name",
+							value: "Joy",
+						},
+					],
 					{
-						criteria: "includes",
-						field: "name",
-						value: "Joy",
+						limit: -5,
 					},
-				], {
-					limit: -5,
-				})
+				)
 				.then(() => done(new Error("Should have thrown an error for invalid limit")))
 				.catch((err) => {
 					expect(err.message).to.include("limit must be a positive integer");
 					done();
 				});
+		});
+
+		describe("With raw cURL HTTP request", () => {
+			it("limits the number of results returned", (done) => {
+				const url = `${ADDRESS}/get.php`;
+				const collection_body = {
+					collection: base.collectionName,
+					command: "search",
+					search: [
+						{
+							criteria: "includes",
+							field: "name",
+							value: "Joy",
+						},
+					],
+					limit: 1,
+				};
+				const body = JSON.stringify(collection_body);
+
+				const req = request(
+					new URL(url),
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							"Content-Length": Buffer.byteLength(body),
+						},
+					},
+					(res) => {
+						let data = "";
+						res.on("data", (chunk) => (data += chunk));
+						res.on("end", () => {
+							try {
+								expect(res.statusCode, data).to.equal(200);
+								const json = JSON.parse(data);
+								expect(json).to.have.all.keys("0");
+								done();
+							} catch (err) {
+								done(err);
+							}
+						});
+					},
+				);
+
+				req.on("error", done);
+				req.write(body);
+				req.end();
+			});
+
+			it("limit value throws error", (done) => {
+				const url = `${ADDRESS}/get.php`;
+				const collection_body = {
+					collection: base.collectionName,
+					command: "search",
+					search: [
+						{
+							criteria: "includes",
+							field: "name",
+							value: "Joy",
+						},
+					],
+					limit: 0,
+				};
+				const body = JSON.stringify(collection_body);
+
+				const req = request(
+					new URL(url),
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							"Content-Length": Buffer.byteLength(body),
+						},
+					},
+					(res) => {
+						let data = "";
+						res.on("data", (chunk) => (data += chunk));
+						res.on("end", () => {
+							try {
+								expect(res.statusCode, data).to.be.eq(400);
+								const json = JSON.parse(data);
+								expect(json).deep.equals({
+									error: "search option limit must be a positive integer",
+								});
+								done();
+							} catch (err) {
+								done(err);
+							}
+						});
+					},
+				);
+
+				req.on("error", done);
+				req.write(body);
+				req.end();
+			});
 		});
 	});
 

--- a/tests/tests-get.spec.mjs
+++ b/tests/tests-get.spec.mjs
@@ -368,7 +368,7 @@ describe("GET operations", () => {
 						field: "name",
 						value: "Joy",
 					},
-				], false, 1)
+				], false, 0)
 				.then(() => done(new Error("Should have thrown an error for invalid limit")))
 				.catch((err) => {
 					expect(err.message).to.include("limit must be a positive integer");

--- a/tests/tests-get.spec.mjs
+++ b/tests/tests-get.spec.mjs
@@ -223,7 +223,7 @@ describe("GET operations", () => {
 		});
 	});
 
-	describe("search(searchOptions, random)", () => {
+	describe("search(searchOptions)", () => {
 		describe("Nested keys test", () => {
 			it("doesn't crash if unknown nested key", (done) => {
 				base
@@ -274,7 +274,7 @@ describe("GET operations", () => {
 		});
 
 		// undefined works because random becomes default parameter false, so false works too
-		const incorrect = [null, "gg", ""];
+		const incorrect = ["gg", "", { random: "gg"}, { random: ""}];
 		incorrect.forEach((incor) => {
 			it(`${JSON.stringify(incor)} seed rejects`, (done) => {
 				base
@@ -294,22 +294,24 @@ describe("GET operations", () => {
 			});
 		});
 
-		it("true seed succeeds", (done) => {
-			base
-				.search(
-					[
-						{
-							criteria: "includes",
-							field: "name",
-							value: "",
-						},
-					],
-					true,
-				)
-				.then(() => done())
-				.catch((err) => {
-					done("Should not reject with error " + JSON.stringify(err));
-				});
+		[true, { random: true }].forEach(trueval => {
+			it(`${JSON.stringify(trueval)} seed succeeds`, (done) => {
+				base
+					.search(
+						[
+							{
+								criteria: "includes",
+								field: "name",
+								value: "",
+							},
+						],
+						trueval,
+					)
+					.then(() => done())
+					.catch((err) => {
+						done("Should not reject with error " + JSON.stringify(err));
+					});
+			});
 		});
 
 		it("Gives the same result for the same seed", (done) => {
@@ -350,7 +352,9 @@ describe("GET operations", () => {
 						field: "name",
 						value: "Joy",
 					},
-				], false, 1)
+				], {
+					limit: 1,
+				})
 				.then((res) => {
 					expect(res).to.be.an("array", "Search result must be an array");
 					expect(res).to.have.lengthOf(1, "Should return exactly 1 result due to limit");
@@ -368,7 +372,9 @@ describe("GET operations", () => {
 						field: "name",
 						value: "Joy",
 					},
-				], false, 0)
+				], {
+					limit: -5,
+				})
 				.then(() => done(new Error("Should have thrown an error for invalid limit")))
 				.catch((err) => {
 					expect(err.message).to.include("limit must be a positive integer");

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -147,6 +147,8 @@ export type SearchOption<T> = {
 		value?: any;
 		/** Is it case sensitive? (default true) */
 		ignoreCase?: boolean;
+		/** Maximum number of results to return (optional) */
+		limit?: number;
 	};
 }[keyof T];
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -147,8 +147,6 @@ export type SearchOption<T> = {
 		value?: any;
 		/** Is it case sensitive? (default true) */
 		ignoreCase?: boolean;
-		/** Maximum number of results to return (optional) */
-		limit?: number;
 	};
 }[keyof T];
 
@@ -225,9 +223,10 @@ declare class Collection<T extends { [ID_FIELD]: string }> {
 	 * Search through the collection
 	 * @param options - Array of search options
 	 * @param random - Random result seed, disabled by default, but can activated with true or a given seed
+	 * @param limit - Limit the number of results returned (only applies if random is false)
 	 * @returns The found elements
 	 */
-	public search(options: SearchOption<RemoveMethods<T>>[], random?: boolean | number): Promise<T[]>;
+	public search(options: SearchOption<RemoveMethods<T>>[], random?: boolean | number, limit?: number): Promise<T[]>;
 
 	/**
 	 * Read the entire collection

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -233,7 +233,10 @@ declare class Collection<T extends { [ID_FIELD]: string }> {
 	 * @param limit - Limit the number of results returned (only applies if random is false)
 	 * @returns The found elements
 	 */
-	public search(options: SearchOption<RemoveMethods<T>>[], random?: boolean | number | SearchResultOptions): Promise<T[]>;
+	public search(
+		options: SearchOption<RemoveMethods<T>>[],
+		random?: boolean | number | SearchResultOptions,
+	): Promise<T[]>;
 
 	/**
 	 * Read the entire collection

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -150,6 +150,13 @@ export type SearchOption<T> = {
 	};
 }[keyof T];
 
+export type SearchResultOptions = {
+	/** Random result seed, disabled by default, but can activated with true or a given seed */
+	random?: boolean | number;
+	/** Limit the number of results returned (only applies if random is false) */
+	limit?: number;
+};
+
 export interface SelectOption<T extends any[]> {
 	/** Selected fields to be returned */
 	fields: T;
@@ -226,7 +233,7 @@ declare class Collection<T extends { [ID_FIELD]: string }> {
 	 * @param limit - Limit the number of results returned (only applies if random is false)
 	 * @returns The found elements
 	 */
-	public search(options: SearchOption<RemoveMethods<T>>[], random?: boolean | number, limit?: number): Promise<T[]>;
+	public search(options: SearchOption<RemoveMethods<T>>[], random?: boolean | number | SearchResultOptions): Promise<T[]>;
 
 	/**
 	 * Read the entire collection


### PR DESCRIPTION
I found a better way than #30 proposed, search endpoint does give options and already had random, so I added limit and made it compatible with it, so it will look like:

```ts
firestorm.collection("textures").search([
    {
        field: "name",
        criteria: "==",
        value,
        ignoreCase: true,
    }
], false, 10)
```

It will give better performance for non-random results, as random results will have a complete computation then the limit applied while non-random will stop search when limit reached